### PR TITLE
feat(core): Tier 1 adaptive anti-entropy interop hardening

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,4 +90,5 @@ jobs:
       - name: Run interop data sync tests
         env:
           NODE_OPTIONS: "--max-old-space-size=6144"
+          ADAPTIVE_INTEROP_STRICT: "true"
         run: yarn test:int:data-sync

--- a/.github/workflows/interop-scale-nightly.yml
+++ b/.github/workflows/interop-scale-nightly.yml
@@ -1,0 +1,90 @@
+name: Interop Scale Nightly
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  adaptive-scale-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        nodes: [12, 24, 50]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable Corepack (Yarn 4)
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build packages
+        run: yarn build
+
+      - name: Adaptive late-joiner scale run (${{ matrix.nodes }} nodes)
+        env:
+          NODE_OPTIONS: "--max-old-space-size=6144"
+          ADAPTIVE_INTEROP_STRICT: "true"
+          INTEROP_WRITE_REPORT_JSON: "true"
+        run: yarn workspace @dechat/core test:int:adaptive-scale -- --nodes ${{ matrix.nodes }}
+
+      - name: Upload interop report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: interop-scale-${{ matrix.nodes }}-nodes
+          path: packages/core/tests/interop/reports/
+          if-no-files-found: ignore
+
+  adaptive-ab-nightly:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable Corepack (Yarn 4)
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build packages
+        run: yarn build
+
+      - name: Fixed vs heuristic A/B
+        env:
+          NODE_OPTIONS: "--max-old-space-size=6144"
+          ADAPTIVE_INTEROP_STRICT: "true"
+          INTEROP_AB_TEST: "true"
+          INTEROP_WRITE_REPORT_JSON: "true"
+        run: yarn workspace @dechat/core test:int:adaptive-ab -- --nodes 6
+
+      - name: Upload A/B interop report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: interop-adaptive-ab
+          path: packages/core/tests/interop/reports/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -130,4 +130,7 @@ dist
 .pnp.*
 .DS_Store
 
+# Interop JSON reports (nightly CI artifacts; keep .gitkeep)
+packages/core/tests/interop/reports/*.json
+
 build/

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -114,22 +114,22 @@ The core architecture has successfully transitioned to a robust, Dependency-Inje
 > **Implementation plan:** [tasks/tier1-adaptive-interop.md](tasks/tier1-adaptive-interop.md) — groomed checklist, CI strategy, phased PRs.
 
 * **Severity:** Medium (confidence / regression prevention for adaptive scheduler)
-* **Status:** Implemented — pending nightly soak
+* **Status:** PR merge gate complete ([PR #37](https://github.com/Ahmed-Abdul-Rahman/de-chat/pull/37) CI green) — nightly soak pending after merge
 * **Depends on:** Task 2.1 adaptive scheduling (PR #36) — **done**
 * **Goal:** Increase statistical confidence in adaptive anti-entropy behaviour **without** new infrastructure. Build on the existing single-host worker-thread interop that already runs in CI.
 
-#### The gap today
+#### Resolved (PR #37)
 
-| Gap | Current state |
-|-----|---------------|
-| Adaptive test waits | `simulateAntiEntropyConvergence` uses fixed sleeps unless `ADAPTIVE_INTEROP_STRICT=true` |
-| CI env | `.github/workflows/ci.yaml` does **not** set `ADAPTIVE_INTEROP_STRICT` |
-| Metrics in reports | Worker snapshot exports `outboundAttempts`, `usefulSyncs`, `lastSyncHashes`, `idleSkips` — not surfaced in `interopTestReporter` summary |
-| Scale | Default 6 nodes; `sim:peak` script references 50 nodes but is not in CI |
-| A/B comparison | No interop scenario runs fixed vs heuristic side-by-side with comparable assertions |
-| Node parametrization | `--nodes` / `--duration` exist via `interopTestReporter.ts` but adaptive scenarios are not exercised at multiple sizes |
+| Item | Resolution |
+|------|------------|
+| Adaptive test waits | Strict `hasTargetData` polling when `ADAPTIVE_INTEROP_STRICT=true` |
+| CI env | `ADAPTIVE_INTEROP_STRICT=true` on data-sync job in `ci.yaml` |
+| Metrics in reports | `summarizeAntiEntropyMetrics` + anti-entropy section in interop reports |
+| Scale | Nightly matrix 12/24/50 via `interop-scale-nightly.yml` |
+| A/B comparison | `simulateAntiEntropyConvergenceAbComparison` + nightly A/B runner |
+| Node parametrization | `interOpTestRunner.adaptiveScale.int.ts` + `--nodes` CLI |
 
-#### Deliverables
+#### Deliverables (all implemented in PR #37)
 
 1. **Enable strict metric polling for adaptive scenario in CI**
    - Set `ADAPTIVE_INTEROP_STRICT=true` for the adaptive interop test job only (or entire `test:int:data-sync` once stable).
@@ -180,11 +180,11 @@ The core architecture has successfully transitioned to a robust, Dependency-Inje
 
 #### Acceptance criteria
 
-- [ ] PR CI (`test:int:data-sync`) passes with `ADAPTIVE_INTEROP_STRICT=true` on adaptive scenario
-- [ ] Interop report prints `idleSkips`, `usefulSyncs`, `floorSyncForces` for late joiner
-- [ ] A/B scenario: both modes converge; heuristic shows `idleSkips > 0` on dormant producers
-- [ ] Nightly 50-node adaptive run completes without worker-thread leak (all workers terminated)
-- [ ] No change to production `adaptive.enabled` default (`false`)
+- [x] PR CI (`test:int:data-sync`) passes with `ADAPTIVE_INTEROP_STRICT=true` ([PR #37](https://github.com/Ahmed-Abdul-Rahman/de-chat/pull/37))
+- [x] Interop report prints `idleSkips`, `usefulSyncs`, `floorSyncForces` for late joiner
+- [ ] A/B scenario: both modes converge; heuristic shows `idleSkips > 0` on dormant producers (nightly, post-merge)
+- [ ] Nightly 50-node adaptive run completes without worker-thread leak (post-merge)
+- [x] No change to production `adaptive.enabled` default (`false`)
 
 #### Out of scope (Tier 1)
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -95,3 +95,267 @@ The core architecture has successfully transitioned to a robust, Dependency-Inje
   2. Encrypt the inner application payload *before* passing it to `GenericDataSerializer`.
   3. The `core` network layer should only route opaque ciphertext blobs identified by a `ContentHash`. 
 * **Affected Modules:** App-layer integration (outside of `core`, but `core` must treat payloads as strictly opaque `Uint8Array`s).
+
+---
+
+## 🧪 Category 5: Adaptive Anti-Entropy — Scale Testing & Realistic Network Simulation
+
+**Context:** Adaptive anti-entropy scheduling shipped in PR [#36](https://github.com/Ahmed-Abdul-Rahman/de-chat/pull/36) (ADR [0003](docs/adr/0003-adaptive-anti-entropy-scheduling.md)). CI validates correctness via worker-thread interop (`packages/core/tests/interop/`). [Testground](https://github.com/testground/testground) was evaluated and **deferred** — libp2p moved to Docker Compose for the same class of problems ([rationale](https://github.com/libp2p/test-plans/issues/103)). This category implements a **two-tier** scale-testing strategy instead.
+
+**Prior art / references:**
+- Current interop harness: `InterOpScenarios.ts`, `interOpTestRunner.dataSync.int.ts`, `nodeWorker.ts`, `nodeWorkerData.ts`
+- Dormant-room scheduling bench: `packages/core/tests/perf/antiEntropyScheduler.bench.ts` (`yarn workspace @dechat/core bench:anti-entropy`)
+- libp2p Compose pattern: [libp2p/test-plans#103](https://github.com/libp2p/test-plans/issues/103), [libp2p/unified-testing](https://github.com/libp2p/unified-testing)
+
+---
+
+### Task 5.1: Tier 1 — Extend In-Process Interop (Worker-Thread Harness)
+
+> **Implementation plan:** [tasks/tier1-adaptive-interop.md](tasks/tier1-adaptive-interop.md) — groomed checklist, CI strategy, phased PRs.
+
+* **Severity:** Medium (confidence / regression prevention for adaptive scheduler)
+* **Status:** Implemented — pending nightly soak
+* **Depends on:** Task 2.1 adaptive scheduling (PR #36) — **done**
+* **Goal:** Increase statistical confidence in adaptive anti-entropy behaviour **without** new infrastructure. Build on the existing single-host worker-thread interop that already runs in CI.
+
+#### The gap today
+
+| Gap | Current state |
+|-----|---------------|
+| Adaptive test waits | `simulateAntiEntropyConvergence` uses fixed sleeps unless `ADAPTIVE_INTEROP_STRICT=true` |
+| CI env | `.github/workflows/ci.yaml` does **not** set `ADAPTIVE_INTEROP_STRICT` |
+| Metrics in reports | Worker snapshot exports `outboundAttempts`, `usefulSyncs`, `lastSyncHashes`, `idleSkips` — not surfaced in `interopTestReporter` summary |
+| Scale | Default 6 nodes; `sim:peak` script references 50 nodes but is not in CI |
+| A/B comparison | No interop scenario runs fixed vs heuristic side-by-side with comparable assertions |
+| Node parametrization | `--nodes` / `--duration` exist via `interopTestReporter.ts` but adaptive scenarios are not exercised at multiple sizes |
+
+#### Deliverables
+
+1. **Enable strict metric polling for adaptive scenario in CI**
+   - Set `ADAPTIVE_INTEROP_STRICT=true` for the adaptive interop test job only (or entire `test:int:data-sync` once stable).
+   - `pollLateJoinerConvergence` in `InterOpScenarios.ts` already polls `antiEntropy.usefulSyncs` every 2s — use this instead of `ANTI_ENTROPY_WAIT_MS` sleep for the adaptive test.
+   - Keep sleep fallback when `ADAPTIVE_INTEROP_STRICT=false` for local debugging / transitional stability.
+
+2. **Enrich worker snapshot + interop report**
+   - Extend `WorkerResult.antiEntropy` snapshot in `nodeWorkerData.ts` with fields already available in `AntiEntropyMetricsStore`:
+     - `floorSyncForces` (`skipCounts.floor_sync_forced`)
+     - `scheduledTicks` (`scheduledTickStarted` counter)
+     - `convergenceMs` (time from late-joiner spawn to first useful sync, measured in worker)
+   - Update `generateTestReport` / `printTestReport` in `interopTestReporter.ts` to print adaptive metrics per node (at least late joiner + aggregate).
+   - Optional: write JSON artifact to `packages/core/tests/interop/reports/` for nightly diffing.
+
+3. **In-process A/B scenario: fixed vs heuristic**
+   - New scenario (or parameterized variant of `simulateAntiEntropyConvergence`):
+     - **Run A:** `adaptive.enabled: false`, `syncIntervalMs: 15_000`
+     - **Run B:** `adaptive.enabled: true`, `scheduler: 'heuristic'`, same base interval bounds
+   - Same topology: N−1 producers, 1 late joiner, same `expectedHashes`.
+   - Assertions:
+     - Both runs: `hasTargetData === true`, `replicaCount >= maxProducerReplicaCount`, `usefulSyncs > 0`
+     - Run B (heuristic): `idleSkips > 0` on at least one producer after convergence phase (dormant room)
+     - Run B wall time ≤ Run A wall time OR document acceptable trade-off in report (heuristic may be slower to converge but cheaper on wire — report both)
+   - File: `interOpTestRunner.dataSync.int.ts` — mark as **nightly** initially if flaky at default CI timeouts.
+
+4. **Parametrized scale runs (nightly, not PR gate)**
+   - Add GitHub Actions workflow `interop-scale-nightly.yml` (or scheduled job on `develop`):
+     - Adaptive late-joiner at `--nodes 12`, `--nodes 24`, `--nodes 50`
+     - `NODE_OPTIONS: --max-old-space-size=6144` (match data-sync job)
+     - Timeout: 60–90 min for 50-node run
+   - Document commands in `packages/core/tests/interop/README.md` (create if missing).
+
+5. **Port additional adaptive scenarios to strict polling**
+   - `simulateSplitBrainConvergence`, `simulateOfflinePeerRevivalConvergence` — add optional `ADAPTIVE_INTEROP_STRICT` polling paths similar to late joiner (poll `usefulSyncs` / hash coverage instead of fixed sleep).
+
+#### Files to touch
+
+| File | Change |
+|------|--------|
+| `.github/workflows/ci.yaml` | `ADAPTIVE_INTEROP_STRICT=true` on data-sync job (or scoped step) |
+| `.github/workflows/interop-scale-nightly.yml` | **New** — scheduled scale matrix |
+| `packages/core/tests/interop/InterOpScenarios.ts` | A/B helper, strict polling for more scenarios |
+| `packages/core/tests/interop/interOpTestRunner.dataSync.int.ts` | A/B test case, scale parametrization |
+| `packages/core/tests/interop/childThread/nodeWorkerData.ts` | Extended `antiEntropy` snapshot |
+| `packages/core/tests/interop/types.ts` | Extended `WorkerResult.antiEntropy` type |
+| `packages/core/tests/interop/interopTestReporter.ts` | Report adaptive metrics |
+| `packages/core/tests/interop/README.md` | **New** — env vars, nightly vs PR commands |
+
+#### Acceptance criteria
+
+- [ ] PR CI (`test:int:data-sync`) passes with `ADAPTIVE_INTEROP_STRICT=true` on adaptive scenario
+- [ ] Interop report prints `idleSkips`, `usefulSyncs`, `floorSyncForces` for late joiner
+- [ ] A/B scenario: both modes converge; heuristic shows `idleSkips > 0` on dormant producers
+- [ ] Nightly 50-node adaptive run completes without worker-thread leak (all workers terminated)
+- [ ] No change to production `adaptive.enabled` default (`false`)
+
+#### Out of scope (Tier 1)
+
+- Real network latency / bandwidth simulation (Tier 2)
+- Cross-container / multi-host deployment
+- Testground or Kubernetes
+
+---
+
+### Task 5.2: Tier 2 — Docker Compose Interop (Real Network Isolation at Scale)
+
+* **Severity:** Medium–High (realistic P2P conditions; catches bugs invisible on localhost worker threads)
+* **Status:** Backlog
+* **Depends on:** Task 5.1 (strict polling + enriched metrics) — recommended first
+* **Goal:** Run the same DeChat convergence scenarios in **isolated containers** with configurable network conditions (latency, jitter, bandwidth, partitions), following the pattern libp2p adopted after leaving Testground.
+
+#### Why Tier 2 (not Testground)
+
+| Need | Compose approach |
+|------|------------------|
+| 50–200 peers, real TCP between containers | `docker compose up --scale node=N` |
+| Latency / jitter / loss | `tc netem` on container egress (documented, no Testground SDK) |
+| Barriers / choreography | Stock Redis + existing scenario timing from `InterOpScenarios.ts` |
+| Debuggability | `docker exec`, `LOG_LEVEL=debug`, attach debugger to any container |
+| TypeScript-native | Reuse `@dechat/core` build — no Go test plan / Testground daemon |
+| CI | GitHub Actions `docker compose` job (nightly); optional manual `act` locally |
+
+#### Proposed layout
+
+```
+packages/core/tests/compose-interop/
+├── README.md                    # setup, scenarios, netem profiles
+├── docker-compose.yml           # base: node image, redis, network
+├── docker-compose.scale.yml     # override for N-node scale profiles
+├── Dockerfile                   # multi-stage: yarn build @dechat/core
+├── scripts/
+│   ├── run-scenario.sh          # entry: late-joiner | split-brain | dormant-room | ab-fixed-heuristic
+│   ├── wait-redis-barrier.sh    # sync producers before late joiner
+│   └── apply-netem.sh           # latency/jitter profile per role
+├── netem/
+│   ├── lan.toml                 # ~1ms RTT (baseline)
+│   ├── wan.toml                 # ~100ms RTT, 10ms jitter
+│   └── lossy.toml               # 1% packet loss + 200ms RTT
+└── scenarios/
+    ├── late-joiner-adaptive.ts  # thin orchestrator (ports InterOpScenarios choreography)
+    ├── split-brain.ts
+    └── dormant-room-ab.ts       # fixed vs heuristic cohort comparison
+```
+
+#### Architecture
+
+```mermaid
+flowchart TB
+  subgraph compose["docker compose network"]
+    R[Redis barrier]
+    P1[Producer 0]
+    P2[Producer 1]
+    PN[Producer N-1]
+    L[Late joiner]
+    R --> P1
+    R --> P2
+    R --> PN
+    R --> L
+    P1 <-- TCP/libp2p --> P2
+    P2 <-- TCP/libp2p --> PN
+    L <-- TCP/libp2p --> P1
+  end
+  Orchestrator[run-scenario.sh] --> R
+  Orchestrator --> L
+```
+
+Each **node container** runs a extracted entrypoint (refactor from `nodeWorker.ts` / `nodeWorkerData.ts`):
+- Env: `NODE_SEED`, `NODE_INDEX`, `TOTAL_NODES`, `ROLE=producer|late-joiner`, `ADAPTIVE_ENABLED`, `SYNC_INTERVAL_MS`, bootstrap multiaddrs
+- HTTP or Redis pub/sub for: `produce_messages`, `set_expected_hashes`, `report_statistics`, `report_hashes`
+- Exit 0/1 with JSON stats on stdout (same shape as `WorkerResult` for report reuse)
+
+#### Scenarios to port (priority order)
+
+| Priority | Scenario | Source | Adaptive focus |
+|----------|----------|--------|----------------|
+| P0 | Late joiner convergence | `simulateAntiEntropyConvergence` | `usefulSyncs > 0`, time-to-converge |
+| P0 | Fixed vs heuristic A/B | Task 5.1 A/B | `idleSkips`, outbound attempts, wall time |
+| P1 | Split-brain heal | `simulateSplitBrainConvergence` | Floor sync under partition heal |
+| P1 | Offline revival | `simulateOfflinePeerRevivalConvergence` | Dormancy → activity transition |
+| P2 | Dormant room at scale | `antiEntropyScheduler.bench.ts` (live P2P) | N producers idle, measure skip rate |
+| P2 | Peer churn | `simulatePeerChurn` | Activity tracker under connect/disconnect |
+
+#### Network profiles (netem)
+
+| Profile | Parameters | Tests |
+|---------|------------|-------|
+| `lan` | negligible delay | Baseline parity with worker interop |
+| `wan` | `delay 50ms 10ms`, `rate 10mbit` | Realistic mobile/WAN chat |
+| `partition` | `iptables` drop between cohort A/B for T seconds | Split-brain + heal |
+| `lossy` | `loss 1% 25%`, `delay 100ms` | Retry / partial sync behaviour |
+
+Apply via `apply-netem.sh` on container start (libp2p test-plans pattern). Do **not** require dynamic mid-test shaping in v1.
+
+#### Deliverables
+
+1. **Extract reusable node runner** from worker thread code
+   - New module: `packages/core/tests/interop/nodeRunner.ts` (or `compose-interop/nodeMain.ts`)
+   - Shared by worker threads (import) and container entrypoint (direct `node` execution)
+   - Avoid duplicating `configureNode`, message handlers, anti-entropy snapshot logic
+
+2. **Docker image + compose stack**
+   - Multi-stage Dockerfile: `yarn install`, `yarn workspace @dechat/core build`, runtime Node 22
+   - `docker-compose.yml`: Redis 7, `node` service, named network `dechat-interop`
+   - Scale producers via `docker compose run` or compose profiles
+
+3. **Orchestration scripts**
+   - Bash driver (libp2p/unified-testing conventions) — scenarios as documented shell scripts
+   - Redis keys: `barrier:mesh-ready`, `barrier:producers-done`, `stats:{index}`
+
+4. **Metrics collection**
+   - Reuse `interopTestReporter.ts` types; orchestrator aggregates container JSON outputs
+   - Write `packages/core/tests/compose-interop/reports/<scenario>-<timestamp>.md`
+   - Compare fixed vs heuristic: outbound attempts, idle skips, convergence time, connection count p95
+
+5. **CI integration (nightly only)**
+   - Workflow: `compose-interop-nightly.yml`
+   - Jobs: `late-joiner-adaptive` (12 nodes, lan), `late-joiner-wan` (12 nodes, wan profile)
+   - Not a PR gate until stable (< 15 min, < 5% flake rate over 7 nights)
+
+6. **Documentation**
+   - `compose-interop/README.md`: prerequisites (Docker 24+), local run, netem profiles, debugging (`docker logs`, `LOG_LEVEL=debug`)
+
+#### Files to create / modify
+
+| Path | Action |
+|------|--------|
+| `packages/core/tests/compose-interop/**` | **New** tree |
+| `packages/core/tests/interop/nodeRunner.ts` | **New** — shared node lifecycle extracted from worker |
+| `packages/core/tests/interop/childThread/nodeWorker.ts` | Refactor to delegate to `nodeRunner` |
+| `packages/core/package.json` | Scripts: `test:compose:late-joiner`, `test:compose:ab` |
+| `.github/workflows/compose-interop-nightly.yml` | **New** scheduled workflow |
+| `BACKLOG.md` | This task |
+
+#### Acceptance criteria
+
+- [ ] `docker compose` late-joiner scenario (6 producers + 1 late joiner, lan) converges with `adaptive.enabled: true`
+- [ ] Same scenario with `wan` netem profile converges within 2× lan wall time (configurable threshold)
+- [ ] A/B report: heuristic shows fewer outbound attempts OR higher `idleSkips` vs fixed in dormant phase
+- [ ] Split-brain scenario: both partitions converge union after heal
+- [ ] No zombie containers after run (`docker compose down -v` in CI teardown)
+- [ ] Orchestrator reuses `WorkerResult` / report types — no second metrics schema
+
+#### Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Compose slower than worker interop | Nightly only; keep Tier 1 as PR gate |
+| GossipSub mesh formation flakes across containers | Reuse `STABILIZE_MS` (120s) from `InterOpScenarios.ts`; Redis barrier after N peers verified |
+| Bootstrap / multiaddr discovery across containers | Explicit `listen` on `0.0.0.0`; publish addrs to Redis; prefer `/ip4/.../tcp/...` over 127.0.0.1 |
+| Image build time in CI | Layer cache; build once per workflow, scale containers from same image |
+| macOS vs Linux netem differences | CI runs on `ubuntu-latest`; document Linux-only netem for local dev |
+
+#### Out of scope (Tier 2 v1)
+
+- Browser / WebRTC nodes in compose
+- 500+ nodes / Kubernetes (revisit only if Compose hits limits — kompose or k3s)
+- Testground migration
+- Cross-version libp2p interop (DeChat-only)
+
+#### Estimated effort
+
+| Phase | Effort | Output |
+|-------|--------|--------|
+| 5.2a — Extract `nodeRunner` + Dockerfile | 2–3 days | Container runs single node |
+| 5.2b — Late joiner + Redis barriers | 2–3 days | First compose scenario green locally |
+| 5.2c — Netem profiles + A/B report | 2 days | wan profile + markdown report |
+| 5.2d — Nightly CI + split-brain | 2 days | Scheduled workflow |
+
+**Total:** ~8–10 dev-days after Tier 1 complete.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,8 @@
     "test:int": "yarn test:int:startup && yarn test:int:data-sync",
     "test:int:startup": "NODE_ENV=perf LOG_LEVEL=INFO node --trace-warnings dist/tests/interop/interOpTestRunner.startup.int.js",
     "test:int:data-sync": "NODE_ENV=perf LOG_LEVEL=INFO node --trace-warnings dist/tests/interop/interOpTestRunner.dataSync.int.js",
+    "test:int:adaptive-ab": "NODE_ENV=perf LOG_LEVEL=INFO node --trace-warnings dist/tests/interop/interOpTestRunner.adaptiveAb.int.js",
+    "test:int:adaptive-scale": "NODE_ENV=perf LOG_LEVEL=INFO node --trace-warnings dist/tests/interop/interOpTestRunner.adaptiveScale.int.js",
     "test:int:narrow": "NODE_ENV=perf LOG_LEVEL=INFO node --trace-warnings dist/tests/interop/interOpTestRunner.startup.int.js --nodes 3 --duration 30",
     "sim": "NODE_ENV=perf node dist/tests/interop/initiateTest.js --nodes 3 --duration 30",
     "sim:peak": "NODE_OPTIONS='--max-old-space-size=4096' NODE_ENV=perf node dist/tests/interop/SimulateMultiNode.int.js --nodes 50 --duration 1500"

--- a/packages/core/src/data-convergence/scheduling/AntiEntropyMetricsStore.ts
+++ b/packages/core/src/data-convergence/scheduling/AntiEntropyMetricsStore.ts
@@ -25,6 +25,9 @@ export interface AntiEntropyMetricsSnapshot {
 
   /** Latest 7-element state vector */
   readonly stateVector: StateVector;
+
+  /** Scheduled anti-entropy ticks evaluated (including skipped ticks) */
+  readonly scheduledTicks: number;
 }
 
 /**
@@ -62,6 +65,9 @@ export class AntiEntropyMetricsStore {
 
   /** Hashes from the most recent outbound sync */
   private lastSyncHashCount = 0;
+
+  /** Total scheduled tick evaluations */
+  private scheduledTickCount = 0;
 
   /**
    * @param synchronizerConfig Full synchronizer strategy config
@@ -141,9 +147,9 @@ export class AntiEntropyMetricsStore {
     return this.consecutiveZeroHashComplete;
   }
 
-  /** Record that a scheduled tick started (counter only) */
+  /** Record that a scheduled tick started */
   recordScheduledTickStarted(): void {
-    // Reserved for future tick-rate metrics; no state mutation yet.
+    this.scheduledTickCount++;
   }
 
   /** Record a skipped scheduled tick with reason */
@@ -225,6 +231,7 @@ export class AntiEntropyMetricsStore {
       consecutiveZeroHashComplete: this.consecutiveZeroHashComplete,
       skipCounts: skipRecord,
       stateVector: this.getStateVector(now),
+      scheduledTicks: this.scheduledTickCount,
     };
   }
 

--- a/packages/core/tests/interop/InterOpScenarios.ts
+++ b/packages/core/tests/interop/InterOpScenarios.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { sampleIndices } from '@dechat/common';
 import { delay } from 'es-toolkit';
 import { isInPercentRange } from './helper';
+import { isAdaptiveInteropStrict, pollAllWorkersTargetData, pollWorkerTargetData } from './interopPolling';
 import {
+  AbComparisonResult,
   AggregatedResult,
   RunWorkersScenario,
   WorkerData,
@@ -17,40 +19,51 @@ const filename = fileURLToPath(import.meta.url);
 const nodeWorkerPath = resolve(dirname(filename), './childThread', './nodeWorker.js');
 const nodeWorkerDataPropPath = resolve(dirname(filename), './childThread', './nodeWorkerData.js');
 
-/** When true, interop scenarios use metric-based polling instead of fixed sleep waits */
-const ADAPTIVE_INTEROP_STRICT = process.env.ADAPTIVE_INTEROP_STRICT === 'true';
+/** Extra settle time after late-joiner convergence so producers accumulate idle skips (adaptive) */
+const DORMANT_SETTLE_MS = 30_000;
 
-/** Poll worker results for anti-entropy useful syncs on the late joiner */
-const pollLateJoinerConvergence = async (
+const waitForLateJoinerConvergence = async (
   workers: WorkerDetails[],
   lateJoinerIndex: number,
-  timeoutMs: number,
+  syncIntervalMs: number,
 ): Promise<void> => {
   const lateJoiner = workers.find((w) => w.workerData.index === lateJoinerIndex);
   if (!lateJoiner) {
     return;
   }
 
-  await new Promise<void>((resolve) => {
-    // biome-ignore lint/suspicious/noExplicitAny: worker message format is dynamic
-    const listener = (msg: any) => {
-      if (msg.type === 'statistics' && msg.stats?.antiEntropy?.usefulSyncs > 0) {
-        lateJoiner.workerRef.off('message', listener);
-        resolve();
-      }
-    };
-    lateJoiner.workerRef.on('message', listener);
+  const antiEntropyWaitMs = syncIntervalMs * 4 + 15_000;
 
-    const poll = setInterval(() => {
-      lateJoiner.workerRef.postMessage({ type: 'statistics' });
-    }, 2_000);
+  if (isAdaptiveInteropStrict()) {
+    const pollResult = await pollWorkerTargetData(lateJoiner.workerRef, 120_000);
+    if (!pollResult.converged) {
+      console.warn(
+        `[Convergence Test] Late joiner poll timed out after ${pollResult.elapsedMs}ms. ` +
+          `Last stats: ${JSON.stringify(pollResult.lastStats?.antiEntropy)}`,
+      );
+    } else {
+      console.log(`[Convergence Test] Late joiner converged in ${pollResult.elapsedMs}ms (strict poll)`);
+    }
+  } else {
+    await delay(antiEntropyWaitMs);
+  }
+};
 
-    setTimeout(() => {
-      clearInterval(poll);
-      lateJoiner.workerRef.off('message', listener);
-      resolve();
-    }, timeoutMs);
-  });
+const waitForAllWorkersTargetData = async (workers: WorkerDetails[], syncIntervalMs: number): Promise<void> => {
+  const antiEntropyWaitMs = syncIntervalMs * 6 + 30_000;
+
+  if (isAdaptiveInteropStrict()) {
+    const { allConverged, results } = await pollAllWorkersTargetData(
+      workers.map((w) => w.workerRef),
+      180_000,
+    );
+    if (!allConverged) {
+      const timedOut = results.filter((r) => !r.converged).length;
+      console.warn(`[Convergence Test] ${timedOut} worker(s) did not converge within strict poll window`);
+    }
+  } else {
+    await delay(antiEntropyWaitMs);
+  }
 };
 
 export const setupScenario = (
@@ -273,7 +286,6 @@ export const simulateAntiEntropyConvergence = (workerDataConfig: WorkerDataConfi
   const REPLICATE_SETTLE_MS = 30_000; // let produced messages fully replicate across producers
   const LATE_JOINER_CONNECT_MS = 20_000; // let the late joiner dial into the mesh
   const syncIntervalMs = workerDataConfig.syncIntervalMs ?? 15_000;
-  const ANTI_ENTROPY_WAIT_MS = syncIntervalMs * 4 + 15_000; // several sync cycles + buffer
 
   const scenario: RunWorkersScenario = async (workers, workerResults, handleComplete, handleWorkerError) => {
     const terminationPromises: Promise<boolean>[] = [];
@@ -324,10 +336,10 @@ export const simulateAntiEntropyConvergence = (workerDataConfig: WorkerDataConfi
     await delay(LATE_JOINER_CONNECT_MS);
     lateJoiner.workerRef.postMessage({ type: 'set_expected_hashes', hashes: expectedHashes });
 
-    if (ADAPTIVE_INTEROP_STRICT) {
-      await pollLateJoinerConvergence(workers, lateJoinerIndex, 120_000);
-    } else {
-      await delay(ANTI_ENTROPY_WAIT_MS);
+    await waitForLateJoinerConvergence(workers, lateJoinerIndex, syncIntervalMs);
+
+    if (workerDataConfig.adaptive?.enabled && isAdaptiveInteropStrict()) {
+      await delay(DORMANT_SETTLE_MS);
     }
 
     terminateWorkers(workers);
@@ -336,6 +348,39 @@ export const simulateAntiEntropyConvergence = (workerDataConfig: WorkerDataConfi
 
   const { scenarioResults } = setupScenario(scenario);
   return scenarioResults;
+};
+
+/** Run fixed then heuristic late-joiner convergence with isolated network IDs */
+export const simulateAntiEntropyConvergenceAbComparison = async (
+  workerDataConfig: WorkerDataConfig,
+): Promise<AbComparisonResult> => {
+  const baseNetworkId = workerDataConfig.networkId;
+
+  const fixedStartedAt = Date.now();
+  const fixedResult = await simulateAntiEntropyConvergence({
+    ...workerDataConfig,
+    networkId: `${baseNetworkId}-fixed-ab`,
+    adaptive: { enabled: false },
+  });
+  const fixedWallMs = Date.now() - fixedStartedAt;
+
+  const heuristicStartedAt = Date.now();
+  const heuristicResult = await simulateAntiEntropyConvergence({
+    ...workerDataConfig,
+    networkId: `${baseNetworkId}-heuristic-ab`,
+    adaptive: {
+      enabled: true,
+      scheduler: 'heuristic',
+      minIntervalMs: workerDataConfig.adaptive?.minIntervalMs ?? 5_000,
+      maxIntervalMs: workerDataConfig.adaptive?.maxIntervalMs ?? 60_000,
+    },
+  });
+  const heuristicWallMs = Date.now() - heuristicStartedAt;
+
+  return {
+    fixed: { result: fixedResult, wallMs: fixedWallMs },
+    heuristic: { result: heuristicResult, wallMs: heuristicWallMs },
+  };
 };
 
 /**
@@ -481,7 +526,6 @@ export const simulateSplitBrainConvergence = (workerDataConfig: WorkerDataConfig
   const REPLICATE_SETTLE_MS = 30_000;
   const HEAL_CONNECT_MS = 45_000;
   const syncIntervalMs = workerDataConfig.syncIntervalMs ?? 15_000;
-  const ANTI_ENTROPY_WAIT_MS = syncIntervalMs * 6 + 30_000;
 
   const scenario: RunWorkersScenario = async (workers, workerResults, handleComplete, handleWorkerError) => {
     const terminationPromises: Promise<boolean>[] = [];
@@ -554,7 +598,7 @@ export const simulateSplitBrainConvergence = (workerDataConfig: WorkerDataConfig
     for (const { workerRef } of workers) {
       workerRef.postMessage({ type: 'set_expected_hashes', hashes: expectedUnion });
     }
-    await delay(ANTI_ENTROPY_WAIT_MS);
+    await waitForAllWorkersTargetData(workers, syncIntervalMs);
 
     terminateWorkers(workers);
     await Promise.all(terminationPromises);
@@ -629,7 +673,18 @@ export const simulateOfflinePeerRevivalConvergence = (
     //    then wait for several sync cycles to converge.
     await delay(RECONNECT_MS);
     revivedWorker.workerRef.postMessage({ type: 'set_expected_hashes', hashes: expectedHashes });
-    await delay(ANTI_ENTROPY_WAIT_MS);
+
+    if (isAdaptiveInteropStrict()) {
+      const pollResult = await pollWorkerTargetData(revivedWorker.workerRef, 180_000);
+      if (!pollResult.converged) {
+        console.warn(
+          `[Revival Convergence Test] Revived peer poll timed out after ${pollResult.elapsedMs}ms. ` +
+            `Last stats: ${JSON.stringify(pollResult.lastStats?.antiEntropy)}`,
+        );
+      }
+    } else {
+      await delay(ANTI_ENTROPY_WAIT_MS);
+    }
 
     terminateWorkers(workers);
     await Promise.all(terminationPromises);

--- a/packages/core/tests/interop/README.md
+++ b/packages/core/tests/interop/README.md
@@ -1,0 +1,48 @@
+# `@dechat/core` interop tests
+
+Worker-thread P2P scenarios that run real DeChat nodes. Integration tests compile to `dist/` — **always `yarn build` before interop**.
+
+## Environment variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `ADAPTIVE_INTEROP_STRICT` | `false` | Poll `hasTargetData` instead of fixed sleeps for anti-entropy scenarios |
+| `INTEROP_AB_TEST` | unset | Enables fixed vs heuristic A/B test in `interOpTestRunner.adaptiveAb.int.ts` |
+| `INTEROP_WRITE_REPORT_JSON` | `false` | Write JSON report to `tests/interop/reports/` |
+
+## Commands
+
+From repo root:
+
+```bash
+yarn build
+yarn test:int:data-sync                    # full data-sync suite (PR CI)
+yarn workspace @dechat/core test:int:adaptive-scale -- --nodes 12
+yarn workspace @dechat/core test:int:adaptive-ab   # requires INTEROP_AB_TEST=true
+```
+
+With strict polling locally:
+
+```bash
+ADAPTIVE_INTEROP_STRICT=true yarn workspace @dechat/core test:int:data-sync
+```
+
+## CI scope
+
+| Workflow | Tests | Strict poll | Max nodes |
+|----------|-------|-------------|-----------|
+| `ci.yaml` → `integration-tests-data-sync` | Full data-sync suite | Yes | 6 (default) |
+| `interop-scale-nightly.yml` | Adaptive scale + A/B | Yes | 12, 24, 50 |
+
+## Anti-entropy report fields
+
+When data sync is enabled, reports include:
+
+- **Late joiner:** `usefulSyncs`, `convergenceMs`, `idleSkips`, `floorSyncForces`, `scheduledTicks`
+- **Producers (aggregate):** total idle skips, outbound attempts, floor sync forces
+
+## Troubleshooting
+
+- **Mesh not formed:** increase stabilize window in `InterOpScenarios.ts` for large node counts
+- **Strict poll timeout:** check `LOG_LEVEL=debug` on workers; verify `set_expected_hashes` was sent
+- **Worker hang:** ensure `terminateWorkers` runs; integration tests must clean up all worker threads

--- a/packages/core/tests/interop/childThread/nodeWorkerData.ts
+++ b/packages/core/tests/interop/childThread/nodeWorkerData.ts
@@ -5,6 +5,7 @@ import { sha256 } from '@dechat/crypto';
 import { Libp2p, Message, ServiceMap } from '@libp2p/interface';
 import { multiaddr } from '@multiformats/multiaddr';
 import { delay, differenceWith, random } from 'es-toolkit';
+import type { AntiEntropyMetricsSnapshot } from '../../../src/data-convergence/scheduling/AntiEntropyMetricsStore';
 import { AntiEntropyMetricsStore } from '../../../src/data-convergence/scheduling/AntiEntropyMetricsStore';
 import { GossipSubPropagation } from '../../../src/data-propagation/broadcast/GossipSubPropagation';
 import { PeerExchangeService } from '../../../src/networking/PeerExchangeService';
@@ -37,6 +38,23 @@ let directStreamMsgsReceivedCount = 0;
 let targetHashesToFetch: string[] | null = null;
 let wireSerializer: WireCodec | null = null;
 let antiEntropyMetrics: AntiEntropyMetricsStore | undefined;
+let convergenceWatchStartedAt: number | null = null;
+let convergenceMsRecorded: number | null = null;
+
+const mapAntiEntropySnapshot = (
+  snapshot: AntiEntropyMetricsSnapshot,
+  convergenceMs?: number,
+): NonNullable<WorkerResult['antiEntropy']> => ({
+  outboundAttempts: snapshot.outboundAttempts,
+  usefulSyncs: snapshot.usefulSyncs,
+  lastSyncHashes: snapshot.lastSyncHashes,
+  idleSkips: snapshot.skipCounts.idle_skip,
+  floorSyncForces: snapshot.skipCounts.floor_sync_forced,
+  scheduledTicks: snapshot.scheduledTicks,
+  zeroHashStreak: snapshot.consecutiveZeroHashComplete,
+  activityScore: snapshot.stateVector[5],
+  ...(convergenceMs !== undefined ? { convergenceMs } : {}),
+});
 
 const hashedMessages = new Map<string, unknown>();
 
@@ -55,12 +73,18 @@ const getReplicationResult = async (replicaStore: ReplicaStoreInterface) => {
 
   const diff = differenceWith(generated.map(normalize), replicated.map(normalize), (gen, rep) => gen === rep);
 
+  const hasTargetData = targetHashesToFetch
+    ? (await Promise.all(targetHashesToFetch.map((h) => replicaStore.has(h)))).every(Boolean)
+    : undefined;
+
+  if (hasTargetData && convergenceWatchStartedAt !== null && convergenceMsRecorded === null) {
+    convergenceMsRecorded = Date.now() - convergenceWatchStartedAt;
+  }
+
   return {
     replicaCount: await replicaStore.size(),
     replicaDataDiff: diff,
-    hasTargetData: targetHashesToFetch
-      ? (await Promise.all(targetHashesToFetch.map((h) => replicaStore.has(h)))).every(Boolean)
-      : undefined,
+    hasTargetData,
   };
 };
 
@@ -75,6 +99,14 @@ const getStatistics = async (
   const replicationResults = replicaStore ? await getReplicationResult(replicaStore) : {};
 
   const antiEntropySnapshot = antiEntropyMetrics?.snapshot();
+  const convergenceMs =
+    convergenceMsRecorded ??
+    (antiEntropySnapshot &&
+    convergenceWatchStartedAt !== null &&
+    'hasTargetData' in replicationResults &&
+    replicationResults.hasTargetData
+      ? Date.now() - convergenceWatchStartedAt
+      : undefined);
 
   return {
     me: selfPeerId,
@@ -91,12 +123,7 @@ const getStatistics = async (
     directStreamMsgsReceivedCount,
     ...(antiEntropySnapshot
       ? {
-          antiEntropy: {
-            outboundAttempts: antiEntropySnapshot.outboundAttempts,
-            usefulSyncs: antiEntropySnapshot.usefulSyncs,
-            lastSyncHashes: antiEntropySnapshot.lastSyncHashes,
-            idleSkips: antiEntropySnapshot.skipCounts.idle_skip,
-          },
+          antiEntropy: mapAntiEntropySnapshot(antiEntropySnapshot, convergenceMs),
         }
       : {}),
     ...replicationResults,
@@ -368,6 +395,8 @@ const runNodeDataReplication = async () => {
       // Record the hashes we expect anti-entropy to deliver, WITHOUT triggering a
       // manual fetch. hasTargetData in the final stats then reflects pure convergence.
       targetHashesToFetch = message.hashes;
+      convergenceWatchStartedAt = Date.now();
+      convergenceMsRecorded = null;
     } else if (message.type === 'terminate') {
       terminateThread = true;
       await terminateAndCleanUp(node, broadcastProp, engine.nodeCleanUp, replicaStore);

--- a/packages/core/tests/interop/interOpTestRunner.adaptiveAb.int.ts
+++ b/packages/core/tests/interop/interOpTestRunner.adaptiveAb.int.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { simulateAntiEntropyConvergenceAbComparison } from './InterOpScenarios';
+import {
+  assertLateJoinerConvergence,
+  generateTestReport,
+  printTestReport,
+  readInteropCliArgs,
+  summarizeAntiEntropyMetrics,
+} from './interopTestReporter';
+
+const { totalNodesArg, runDurationSecArg, messageRateArg, pubsubTopicArg, networkIdArg } = readInteropCliArgs();
+
+const runAbTest = process.env.INTEROP_AB_TEST === 'true';
+
+describe('Interop - Adaptive Anti-Entropy A/B', () => {
+  it('should A/B compare fixed vs heuristic late-joiner convergence', { skip: !runAbTest }, async () => {
+    const totalNodes = totalNodesArg ?? 6;
+    const runDurationSec = runDurationSecArg ?? 300;
+    const messageRate = messageRateArg ?? 5;
+    const pubsubTopic = pubsubTopicArg ?? '/bench/1';
+    const networkId = networkIdArg ?? 'benchnet-ab';
+    const syncIntervalMs = 15_000;
+
+    const comparison = await simulateAntiEntropyConvergenceAbComparison({
+      testType: 'REPLICATION',
+      replicationType: 'TOPIC_BASED',
+      dataSyncEnabled: true,
+      syncIntervalMs,
+      totalNodes,
+      runDurationSec,
+      messageRate,
+      pubsubTopic,
+      networkId,
+      bootstrapMultiaddrs: [],
+    });
+
+    const fixedPassed = assertLateJoinerConvergence(comparison.fixed.result.workerResults);
+    const heuristicPassed = assertLateJoinerConvergence(comparison.heuristic.result.workerResults);
+
+    const fixedSummary = summarizeAntiEntropyMetrics(comparison.fixed.result.workerResults);
+    const heuristicSummary = summarizeAntiEntropyMetrics(comparison.heuristic.result.workerResults);
+
+    assert.ok(fixedSummary, 'Fixed run should export anti-entropy metrics');
+    assert.ok(heuristicSummary, 'Heuristic run should export anti-entropy metrics');
+
+    assert.ok(
+      heuristicSummary.producerIdleSkipsTotal > fixedSummary.producerIdleSkipsTotal,
+      `Heuristic should idle-skip more on producers (heuristic=${heuristicSummary.producerIdleSkipsTotal}, fixed=${fixedSummary.producerIdleSkipsTotal})`,
+    );
+
+    const passed = fixedPassed && heuristicPassed;
+
+    const report = generateTestReport(
+      'Anti-Entropy Fixed vs Heuristic A/B',
+      totalNodes,
+      runDurationSec,
+      comparison.heuristic.result,
+      passed,
+      {
+        antiEntropy: heuristicSummary,
+        abComparison: {
+          fixedWallMs: comparison.fixed.wallMs,
+          heuristicWallMs: comparison.heuristic.wallMs,
+          fixed: fixedSummary,
+          heuristic: heuristicSummary,
+        },
+      },
+    );
+    printTestReport(report);
+  });
+});

--- a/packages/core/tests/interop/interOpTestRunner.adaptiveScale.int.ts
+++ b/packages/core/tests/interop/interOpTestRunner.adaptiveScale.int.ts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import { simulateAntiEntropyConvergence } from './InterOpScenarios';
+import {
+  assertLateJoinerConvergence,
+  generateTestReport,
+  printTestReport,
+  readInteropCliArgs,
+  summarizeAntiEntropyMetrics,
+} from './interopTestReporter';
+
+const { totalNodesArg, runDurationSecArg, messageRateArg, pubsubTopicArg, networkIdArg } = readInteropCliArgs();
+
+describe('Interop - Adaptive Anti-Entropy Scale', () => {
+  it('should converge a late-joining peer with adaptive heuristic scheduler at scale', async () => {
+    const totalNodes = totalNodesArg ?? 6;
+    const runDurationSec = runDurationSecArg ?? 300;
+    const messageRate = messageRateArg ?? 5;
+    const pubsubTopic = pubsubTopicArg ?? '/bench/1';
+    const networkId = networkIdArg ?? 'benchnet-scale';
+    const syncIntervalMs = 15_000;
+
+    const scenarioStartedAt = Date.now();
+    const aggregatedResults = await simulateAntiEntropyConvergence({
+      testType: 'REPLICATION',
+      replicationType: 'TOPIC_BASED',
+      dataSyncEnabled: true,
+      syncIntervalMs,
+      adaptive: {
+        enabled: true,
+        scheduler: 'heuristic',
+        minIntervalMs: 5_000,
+        maxIntervalMs: 60_000,
+      },
+      totalNodes,
+      runDurationSec,
+      messageRate,
+      pubsubTopic,
+      networkId,
+      bootstrapMultiaddrs: [],
+    });
+    const scenarioWallMs = Date.now() - scenarioStartedAt;
+
+    const { workerResults } = aggregatedResults;
+    const passed = assertLateJoinerConvergence(workerResults);
+
+    const report = generateTestReport(
+      `Anti-Entropy Adaptive Scale (${totalNodes} nodes)`,
+      totalNodes,
+      runDurationSec,
+      aggregatedResults,
+      passed,
+      {
+        antiEntropy: summarizeAntiEntropyMetrics(workerResults),
+        scenarioWallMs,
+      },
+    );
+    printTestReport(report);
+  });
+});

--- a/packages/core/tests/interop/interOpTestRunner.dataSync.int.ts
+++ b/packages/core/tests/interop/interOpTestRunner.dataSync.int.ts
@@ -8,7 +8,13 @@ import {
   simulateOfflinePeerRevivalConvergence,
   simulateSplitBrainConvergence,
 } from './InterOpScenarios';
-import { generateTestReport, printTestReport, readInteropCliArgs } from './interopTestReporter';
+import {
+  assertLateJoinerConvergence,
+  generateTestReport,
+  printTestReport,
+  readInteropCliArgs,
+  summarizeAntiEntropyMetrics,
+} from './interopTestReporter';
 
 const { totalNodesArg, runDurationSecArg, messageRateArg, pubsubTopicArg, networkIdArg } = readInteropCliArgs();
 
@@ -245,41 +251,8 @@ describe('Interop - Data Convergence (Anti-Entropy) Tests', () => {
     });
 
     const { workerResults } = aggregatedResults;
-    const lateJoiner = workerResults.find((r) => r.hasTargetData !== undefined);
-    const producers = workerResults.filter((r) => r.hasTargetData === undefined);
-    const maxProducerReplicaCount = Math.max(0, ...producers.map((r) => r.replicaCount ?? 0));
 
-    let passed = true;
-
-    if (!lateJoiner || !lateJoiner.hasTargetData) {
-      passed = false;
-      console.log(
-        `⚠️ [Adaptive] Late joiner failed to converge. replicaCount: ${lateJoiner?.replicaCount}, ` +
-          `antiEntropy: ${JSON.stringify(lateJoiner?.antiEntropy)}`,
-      );
-    }
-
-    if (lateJoiner && (lateJoiner.replicaCount ?? 0) < maxProducerReplicaCount) {
-      passed = false;
-      console.log(
-        `⚠️ [Adaptive] Late joiner store incomplete: ${lateJoiner.replicaCount} < producer max ${maxProducerReplicaCount}`,
-      );
-    }
-
-    if ((lateJoiner?.antiEntropy?.usefulSyncs ?? 0) <= 0) {
-      passed = false;
-      console.log(`⚠️ [Adaptive] Late joiner reported no useful anti-entropy syncs`);
-    }
-
-    assert.ok(lateJoiner?.hasTargetData, `Adaptive: late joiner failed to converge via anti-entropy`);
-    assert.ok(
-      (lateJoiner?.replicaCount ?? 0) >= maxProducerReplicaCount,
-      `Adaptive: late joiner store (${lateJoiner?.replicaCount}) did not reach producer size (${maxProducerReplicaCount})`,
-    );
-    assert.ok(
-      (lateJoiner?.antiEntropy?.usefulSyncs ?? 0) > 0,
-      'Adaptive: late joiner should report at least one useful anti-entropy sync',
-    );
+    const passed = assertLateJoinerConvergence(workerResults);
 
     const report = generateTestReport(
       'Anti-Entropy Adaptive Heuristic Convergence',
@@ -287,6 +260,7 @@ describe('Interop - Data Convergence (Anti-Entropy) Tests', () => {
       runDurationSec,
       aggregatedResults,
       passed,
+      { antiEntropy: summarizeAntiEntropyMetrics(workerResults) },
     );
     printTestReport(report);
   });

--- a/packages/core/tests/interop/interopPolling.ts
+++ b/packages/core/tests/interop/interopPolling.ts
@@ -1,0 +1,76 @@
+import type { Worker } from 'node:worker_threads';
+import type { WorkerResult } from './types';
+
+/** Result of polling a worker until a stats predicate succeeds or timeout */
+export type PollResult = {
+  readonly converged: boolean;
+  readonly elapsedMs: number;
+  readonly lastStats?: WorkerResult;
+};
+
+/** When true, interop scenarios use metric-based polling instead of fixed sleep waits */
+export const isAdaptiveInteropStrict = (): boolean => process.env.ADAPTIVE_INTEROP_STRICT === 'true';
+
+/**
+ * Poll a worker's statistics until predicate(stats) is true or timeout elapses.
+ */
+export const pollWorkerStats = (
+  workerRef: Worker,
+  predicate: (stats: WorkerResult) => boolean,
+  intervalMs: number,
+  timeoutMs: number,
+): Promise<PollResult> => {
+  const startedAt = Date.now();
+
+  return new Promise((resolve) => {
+    let lastStats: WorkerResult | undefined;
+    let poll: ReturnType<typeof setInterval> | undefined;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = (): void => {
+      if (poll) clearInterval(poll);
+      if (timeout) clearTimeout(timeout);
+      workerRef.off('message', listener);
+    };
+
+    // biome-ignore lint/suspicious/noExplicitAny: worker message format is dynamic
+    const listener = (msg: any) => {
+      if (msg.type !== 'statistics' || !msg.stats) {
+        return;
+      }
+      lastStats = msg.stats as WorkerResult;
+      if (predicate(lastStats)) {
+        cleanup();
+        resolve({ converged: true, elapsedMs: Date.now() - startedAt, lastStats });
+      }
+    };
+
+    workerRef.on('message', listener);
+    poll = setInterval(() => {
+      workerRef.postMessage({ type: 'statistics' });
+    }, intervalMs);
+    timeout = setTimeout(() => {
+      cleanup();
+      resolve({ converged: false, elapsedMs: Date.now() - startedAt, lastStats });
+    }, timeoutMs);
+
+    workerRef.postMessage({ type: 'statistics' });
+  });
+};
+
+/** Poll until worker reports all expected target hashes are present */
+export const pollWorkerTargetData = (workerRef: Worker, timeoutMs: number, intervalMs = 2_000): Promise<PollResult> =>
+  pollWorkerStats(workerRef, (stats) => stats.hasTargetData === true, intervalMs, timeoutMs);
+
+/** Poll every worker until all report hasTargetData */
+export const pollAllWorkersTargetData = async (
+  workerRefs: readonly Worker[],
+  timeoutMs: number,
+  intervalMs = 2_000,
+): Promise<{ readonly allConverged: boolean; readonly results: readonly PollResult[] }> => {
+  const results = await Promise.all(workerRefs.map((ref) => pollWorkerTargetData(ref, timeoutMs, intervalMs)));
+  return {
+    allConverged: results.every((r) => r.converged),
+    results,
+  };
+};

--- a/packages/core/tests/interop/interopTestReporter.ts
+++ b/packages/core/tests/interop/interopTestReporter.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { parseArg } from './helper';
-import { AggregatedResult, TestReport, WorkerResult } from './types';
+import { AbComparisonReport, AggregatedResult, AntiEntropyInteropSummary, TestReport, WorkerResult } from './types';
 
 export const readInteropCliArgs = () => ({
   totalNodesArg: parseArg<number>('nodes'),
@@ -10,13 +12,42 @@ export const readInteropCliArgs = () => ({
   networkIdArg: parseArg<string>('net'),
 });
 
+/** Aggregate anti-entropy metrics across late joiner and producer workers */
+export const summarizeAntiEntropyMetrics = (
+  workerResults: readonly WorkerResult[],
+): AntiEntropyInteropSummary | undefined => {
+  if (!workerResults.some((r) => r.antiEntropy)) {
+    return undefined;
+  }
+
+  const lateJoiner = workerResults.find((r) => r.hasTargetData !== undefined);
+  const producers = workerResults.filter((r) => r.hasTargetData === undefined && r.antiEntropy);
+
+  return {
+    lateJoiner: lateJoiner?.antiEntropy,
+    producerIdleSkipsTotal: producers.reduce((sum, r) => sum + (r.antiEntropy?.idleSkips ?? 0), 0),
+    producerOutboundAttemptsTotal: producers.reduce((sum, r) => sum + (r.antiEntropy?.outboundAttempts ?? 0), 0),
+    producerFloorSyncForcesTotal: producers.reduce((sum, r) => sum + (r.antiEntropy?.floorSyncForces ?? 0), 0),
+    producerScheduledTicksTotal: producers.reduce((sum, r) => sum + (r.antiEntropy?.scheduledTicks ?? 0), 0),
+  };
+};
+
+export type GenerateTestReportOptions = {
+  readonly antiEntropy?: AntiEntropyInteropSummary;
+  readonly scenarioWallMs?: number;
+  readonly abComparison?: AbComparisonReport;
+};
+
 export const generateTestReport = (
   testName: string,
   totalNodes: number,
   duration: number,
   aggregatedResults: AggregatedResult,
   passed: boolean,
+  options: GenerateTestReportOptions = {},
 ): TestReport => {
+  const antiEntropy = options.antiEntropy ?? summarizeAntiEntropyMetrics(aggregatedResults.workerResults);
+
   return {
     testName,
     totalNodes,
@@ -24,7 +55,25 @@ export const generateTestReport = (
     summary: aggregatedResults.summary,
     passed,
     timestamp: new Date().toISOString(),
+    antiEntropy,
+    scenarioWallMs: options.scenarioWallMs,
+    abComparison: options.abComparison,
   };
+};
+
+const printAntiEntropySection = (antiEntropy: AntiEntropyInteropSummary): void => {
+  console.log('\n--- Anti-Entropy Metrics ---');
+  if (antiEntropy.lateJoiner) {
+    console.log(`  Late joiner usefulSyncs: ${antiEntropy.lateJoiner.usefulSyncs}`);
+    console.log(`  Late joiner convergenceMs: ${antiEntropy.lateJoiner.convergenceMs ?? 'n/a'}`);
+    console.log(`  Late joiner idleSkips: ${antiEntropy.lateJoiner.idleSkips ?? 0}`);
+    console.log(`  Late joiner floorSyncForces: ${antiEntropy.lateJoiner.floorSyncForces ?? 0}`);
+    console.log(`  Late joiner scheduledTicks: ${antiEntropy.lateJoiner.scheduledTicks ?? 0}`);
+  }
+  console.log(`  Producer idleSkips (total): ${antiEntropy.producerIdleSkipsTotal}`);
+  console.log(`  Producer outboundAttempts (total): ${antiEntropy.producerOutboundAttemptsTotal}`);
+  console.log(`  Producer floorSyncForces (total): ${antiEntropy.producerFloorSyncForcesTotal}`);
+  console.log(`  Producer scheduledTicks (total): ${antiEntropy.producerScheduledTicksTotal}`);
 };
 
 export const printTestReport = (report: TestReport): void => {
@@ -34,6 +83,9 @@ export const printTestReport = (report: TestReport): void => {
   console.log(`Status: ${report.passed ? '✅ PASSED' : '❌ FAILED'}`);
   console.log(`Nodes: ${report.totalNodes}`);
   console.log(`Duration: ${report.duration}s`);
+  if (report.scenarioWallMs !== undefined) {
+    console.log(`Scenario wall time: ${(report.scenarioWallMs / 1000).toFixed(1)}s`);
+  }
   console.log(`Timestamp: ${report.timestamp}`);
   console.log('\n--- Connection Metrics ---');
   console.log(`  P50: ${report.summary.connections.p50.toFixed(2)}`);
@@ -47,7 +99,44 @@ export const printTestReport = (report: TestReport): void => {
   console.log(`  P50: ${report.summary.ttfVerifiedMs.p50.toFixed(2)}`);
   console.log(`  P95: ${report.summary.ttfVerifiedMs.p95.toFixed(2)}`);
   console.log(`  Avg: ${report.summary.ttfVerifiedMs.avg.toFixed(2)}`);
+
+  if (report.antiEntropy) {
+    printAntiEntropySection(report.antiEntropy);
+  }
+
+  if (report.abComparison) {
+    const { fixed, heuristic, fixedWallMs, heuristicWallMs } = report.abComparison;
+    console.log('\n--- A/B Comparison (fixed vs heuristic) ---');
+    console.log(`  Fixed wallMs: ${fixedWallMs}`);
+    console.log(`  Heuristic wallMs: ${heuristicWallMs}`);
+    console.log(
+      `  Heuristic producer idleSkips: ${heuristic.producerIdleSkipsTotal} vs Fixed: ${fixed.producerIdleSkipsTotal}`,
+    );
+    console.log(
+      `  Heuristic producer outboundAttempts: ${heuristic.producerOutboundAttemptsTotal} vs Fixed: ${fixed.producerOutboundAttemptsTotal}`,
+    );
+    if (heuristic.lateJoiner?.convergenceMs !== undefined && fixed.lateJoiner?.convergenceMs !== undefined) {
+      console.log(
+        `  Heuristic lateJoiner convergenceMs: ${heuristic.lateJoiner.convergenceMs} vs Fixed: ${fixed.lateJoiner.convergenceMs}`,
+      );
+    }
+  }
+
   console.log('='.repeat(80) + '\n');
+
+  if (process.env.INTEROP_WRITE_REPORT_JSON === 'true') {
+    writeInteropReportJson(report);
+  }
+};
+
+/** Write report JSON for nightly artifact collection */
+export const writeInteropReportJson = (report: TestReport): void => {
+  const reportsDir = resolve(process.cwd(), 'tests/interop/reports');
+  mkdirSync(reportsDir, { recursive: true });
+  const safeName = report.testName.replace(/[^a-zA-Z0-9-_]+/g, '-').toLowerCase();
+  const filePath = resolve(reportsDir, `${safeName}-${report.timestamp.replace(/[:.]/g, '-')}.json`);
+  writeFileSync(filePath, JSON.stringify(report, null, 2));
+  console.log(`[Interop] Report written to ${filePath}`);
 };
 
 export const assertStartupWorkerResults = (workerResults: WorkerResult[], totalNodes: number): boolean => {
@@ -67,6 +156,42 @@ export const assertStartupWorkerResults = (workerResults: WorkerResult[], totalN
     assert.ok(verifiedOk, `Node ${index} verified peers below threshold`);
     assert.ok(connectionsOk, `Node ${index} connections below threshold`);
   });
+
+  return passed;
+};
+
+/** Shared assertions for late-joiner anti-entropy convergence scenarios */
+export const assertLateJoinerConvergence = (workerResults: readonly WorkerResult[]): boolean => {
+  const lateJoiner = workerResults.find((r) => r.hasTargetData !== undefined);
+  const producers = workerResults.filter((r) => r.hasTargetData === undefined);
+  const maxProducerReplicaCount = Math.max(0, ...producers.map((r) => r.replicaCount ?? 0));
+
+  let passed = true;
+
+  if (!lateJoiner?.hasTargetData) {
+    passed = false;
+    console.log(
+      `⚠️ Late joiner failed to converge. replicaCount: ${lateJoiner?.replicaCount}, ` +
+        `antiEntropy: ${JSON.stringify(lateJoiner?.antiEntropy)}`,
+    );
+  }
+
+  if (lateJoiner && (lateJoiner.replicaCount ?? 0) < maxProducerReplicaCount) {
+    passed = false;
+    console.log(`⚠️ Late joiner store incomplete: ${lateJoiner.replicaCount} < producer max ${maxProducerReplicaCount}`);
+  }
+
+  if ((lateJoiner?.antiEntropy?.usefulSyncs ?? 0) <= 0) {
+    passed = false;
+    console.log('⚠️ Late joiner reported no useful anti-entropy syncs');
+  }
+
+  assert.ok(lateJoiner?.hasTargetData, 'Late joiner failed to converge missing hashes via anti-entropy');
+  assert.ok(
+    (lateJoiner?.replicaCount ?? 0) >= maxProducerReplicaCount,
+    `Late joiner store (${lateJoiner?.replicaCount}) did not reach producer size (${maxProducerReplicaCount})`,
+  );
+  assert.ok((lateJoiner?.antiEntropy?.usefulSyncs ?? 0) > 0, 'Late joiner should report at least one useful sync');
 
   return passed;
 };

--- a/packages/core/tests/interop/types.ts
+++ b/packages/core/tests/interop/types.ts
@@ -20,6 +20,16 @@ export type WorkerResult = {
     lastSyncHashes: number;
     /** Scheduled ticks skipped due to idle dormancy (adaptive mode) */
     idleSkips?: number;
+    /** Forced syncs at maxIntervalMs ceiling despite idle state */
+    floorSyncForces?: number;
+    /** Total scheduled tick evaluations */
+    scheduledTicks?: number;
+    /** Consecutive zero-hash complete syncs at snapshot time */
+    zeroHashStreak?: number;
+    /** Replication activity score from state vector index 5 */
+    activityScore?: number;
+    /** Ms from set_expected_hashes to first full target hash coverage */
+    convergenceMs?: number;
   };
 };
 
@@ -47,6 +57,21 @@ export type Summary = {
   };
 };
 
+export type AntiEntropyInteropSummary = {
+  readonly lateJoiner?: WorkerResult['antiEntropy'];
+  readonly producerIdleSkipsTotal: number;
+  readonly producerOutboundAttemptsTotal: number;
+  readonly producerFloorSyncForcesTotal: number;
+  readonly producerScheduledTicksTotal: number;
+};
+
+export type AbComparisonReport = {
+  readonly fixedWallMs: number;
+  readonly heuristicWallMs: number;
+  readonly fixed: AntiEntropyInteropSummary;
+  readonly heuristic: AntiEntropyInteropSummary;
+};
+
 export interface TestReport {
   testName: string;
   totalNodes: number;
@@ -54,11 +79,19 @@ export interface TestReport {
   summary: Summary;
   passed: boolean;
   timestamp: string;
+  antiEntropy?: AntiEntropyInteropSummary;
+  scenarioWallMs?: number;
+  abComparison?: AbComparisonReport;
 }
 
 export type AggregatedResult = {
   workerResults: WorkerResult[];
   summary: Summary;
+};
+
+export type AbComparisonResult = {
+  readonly fixed: { readonly result: AggregatedResult; readonly wallMs: number };
+  readonly heuristic: { readonly result: AggregatedResult; readonly wallMs: number };
 };
 
 export type WorkerData = {

--- a/packages/core/tests/unit/data-convergence/scheduling/AntiEntropyMetricsStore.unit.test.ts
+++ b/packages/core/tests/unit/data-convergence/scheduling/AntiEntropyMetricsStore.unit.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { DECHAT_DEFAULTS } from '../../../../src/config/defaults';
+import { AntiEntropyMetricsStore } from '../../../../src/data-convergence/scheduling/AntiEntropyMetricsStore';
+
+describe('AntiEntropyMetricsStore', () => {
+  it('increments scheduledTicks on each recordScheduledTickStarted call', () => {
+    const store = new AntiEntropyMetricsStore(DECHAT_DEFAULTS.strategies.synchronizer);
+
+    store.recordScheduledTickStarted();
+    store.recordScheduledTickStarted();
+    store.recordSkip('idle_skip');
+    store.recordScheduledTickStarted();
+
+    const snap = store.snapshot();
+    expect(snap.scheduledTicks).toBe(3);
+    expect(snap.skipCounts.idle_skip).toBe(1);
+  });
+});

--- a/tasks/tier1-adaptive-interop.md
+++ b/tasks/tier1-adaptive-interop.md
@@ -4,7 +4,7 @@
 **ADR ref:** [docs/adr/0003-adaptive-anti-entropy-scheduling.md](../docs/adr/0003-adaptive-anti-entropy-scheduling.md)  
 **Prerequisite:** PR [#36](https://github.com/Ahmed-Abdul-Rahman/de-chat/pull/36) merged (adaptive scheduling + baseline adaptive interop test)  
 **Blocks:** Bandit scheduler (Step 7 in `todo.md`) — implement **after** Tier 1 nightly CI is green  
-**Status:** Implemented — pending CI / nightly soak  
+**Status:** PR merge gate complete ([PR #37](https://github.com/Ahmed-Abdul-Rahman/de-chat/pull/37) CI green) — nightly soak pending after merge  
 **Goal:** Increase confidence in adaptive anti-entropy at scale using the **existing worker-thread interop harness** — no Docker, no Testground.
 
 ---
@@ -486,15 +486,15 @@ flowchart TB
 
 ### PR merge gate (Tier 1 complete for PR)
 
-- [ ] `yarn workspace @dechat/core test` — all unit tests pass
-- [ ] `yarn build && yarn test:int:data-sync` with `ADAPTIVE_INTEROP_STRICT=true` — green
-- [ ] Adaptive late-joiner report prints anti-entropy section with `usefulSyncs`, `convergenceMs`, `idleSkips`
-- [ ] `scheduledTicks` increments in store (unit tested)
-- [ ] No change to `adaptive.enabled` default in `config/defaults.ts`
+- [x] `yarn workspace @dechat/core test` — all unit tests pass (CI #37)
+- [x] `yarn build && yarn test:int:data-sync` with `ADAPTIVE_INTEROP_STRICT=true` — green (CI #37, ~31m)
+- [x] Adaptive late-joiner report prints anti-entropy section with `usefulSyncs`, `convergenceMs`, `idleSkips`
+- [x] `scheduledTicks` increments in store (unit tested)
+- [x] No change to `adaptive.enabled` default in `config/defaults.ts`
 
 ### Nightly gate (Tier 1 fully complete)
 
-- [ ] `interop-scale-nightly.yml` green for matrix 12 / 24 / 50
+- [ ] `interop-scale-nightly.yml` green for matrix 12 / 24 / 50 (runs after merge to `develop`)
 - [ ] A/B test: both modes converge; heuristic `producerIdleSkipsTotal >= 1`
 - [ ] JSON artifacts uploaded; no worker-thread hang (all workers terminate)
 - [ ] 7 consecutive nightly greens before starting bandit scheduler work
@@ -531,40 +531,40 @@ Use this as the PR sequence — one or more PRs per phase is fine.
 
 ### PR 1 — Metrics + reporting (Phases 1–2)
 
-- [ ] 1.1 `scheduledTickCount` in store + unit test
-- [ ] 1.2 Extended `WorkerResult.antiEntropy` + worker snapshot mapping
-- [ ] 1.3 `convergenceMs` on late joiner (`set_expected_hashes` watch)
-- [ ] 2.1–2.3 `summarizeAntiEntropyMetrics` + report printing
-- [ ] 2.4 JSON artifact + `.gitkeep` + gitignore
-- [ ] Verify: unit tests + manual `test:int:data-sync` (strict off)
+- [x] 1.1 `scheduledTickCount` in store + unit test
+- [x] 1.2 Extended `WorkerResult.antiEntropy` + worker snapshot mapping
+- [x] 1.3 `convergenceMs` on late joiner (`set_expected_hashes` watch)
+- [x] 2.1–2.3 `summarizeAntiEntropyMetrics` + report printing
+- [x] 2.4 JSON artifact + `.gitkeep` + gitignore
+- [x] Verify: unit tests + `test:int:data-sync` (CI #37)
 
 ### PR 2 — Strict CI polling (Phase 3)
 
-- [ ] 3.1 Extract `interopPolling.ts`
-- [ ] 3.2 Change poll success to `hasTargetData === true`
-- [ ] 3.3 `ADAPTIVE_INTEROP_STRICT=true` in `ci.yaml`
-- [ ] Verify: full data-sync CI green
+- [x] 3.1 Extract `interopPolling.ts`
+- [x] 3.2 Change poll success to `hasTargetData === true`
+- [x] 3.3 `ADAPTIVE_INTEROP_STRICT=true` in `ci.yaml`
+- [x] Verify: full data-sync CI green
 
 ### PR 3 — A/B + extended scenarios (Phases 4–5)
 
-- [ ] 4.1 `simulateAntiEntropyConvergenceAbComparison`
-- [ ] 4.2 `interOpTestRunner.adaptiveAb.int.ts` + package script
-- [ ] 4.3 Dormant-phase producer idle skip assertion
-- [ ] 5.1–5.2 Strict poll for split-brain + revival
-- [ ] Verify: local A/B run with `INTEROP_AB_TEST=true`
+- [x] 4.1 `simulateAntiEntropyConvergenceAbComparison`
+- [x] 4.2 `interOpTestRunner.adaptiveAb.int.ts` + package script
+- [x] 4.3 Dormant-phase producer idle skip assertion
+- [x] 5.1–5.2 Strict poll for split-brain + revival
+- [ ] Verify: local/nightly A/B run with `INTEROP_AB_TEST=true` (post-merge nightly)
 
 ### PR 4 — Nightly CI + docs (Phases 6–7)
 
-- [ ] 6.1 `interop-scale-nightly.yml`
-- [ ] 6.2 `interOpTestRunner.adaptiveScale.int.ts`
-- [ ] 7.1 `tests/interop/README.md`
-- [ ] Update `BACKLOG.md` Task 5.1 status → In progress / Done
-- [ ] Soak: monitor 7 nightly runs
+- [x] 6.1 `interop-scale-nightly.yml`
+- [x] 6.2 `interOpTestRunner.adaptiveScale.int.ts`
+- [x] 7.1 `tests/interop/README.md`
+- [x] Update `BACKLOG.md` Task 5.1 status
+- [ ] Soak: monitor 7 nightly runs (after merge)
 
 ---
 
 ## Approval
 
-**Pending your review.** Suggested starting point: **PR 1** (metrics + reporting) — zero CI risk, immediate observability win.
+**PR merge gate approved** — [PR #37](https://github.com/Ahmed-Abdul-Rahman/de-chat/pull/37) CI green (unit + startup + data-sync interop).
 
-After approval, begin with Phase 1.1 (`scheduledTickCount`).
+**Remaining:** merge to `develop`, then complete nightly gate (7 consecutive greens) before bandit scheduler (Step 7).

--- a/tasks/tier1-adaptive-interop.md
+++ b/tasks/tier1-adaptive-interop.md
@@ -1,0 +1,570 @@
+# Task: Tier 1 — Adaptive Anti-Entropy Interop Hardening
+
+**Backlog ref:** [BACKLOG.md § Task 5.1](../BACKLOG.md#task-51-tier-1--extend-in-process-interop-worker-thread-harness)  
+**ADR ref:** [docs/adr/0003-adaptive-anti-entropy-scheduling.md](../docs/adr/0003-adaptive-anti-entropy-scheduling.md)  
+**Prerequisite:** PR [#36](https://github.com/Ahmed-Abdul-Rahman/de-chat/pull/36) merged (adaptive scheduling + baseline adaptive interop test)  
+**Blocks:** Bandit scheduler (Step 7 in `todo.md`) — implement **after** Tier 1 nightly CI is green  
+**Status:** Implemented — pending CI / nightly soak  
+**Goal:** Increase confidence in adaptive anti-entropy at scale using the **existing worker-thread interop harness** — no Docker, no Testground.
+
+---
+
+## Executive summary
+
+PR #36 shipped adaptive scheduling and a single adaptive late-joiner interop test. Tier 1 closes the observability and CI gaps so we can:
+
+1. Stop guessing convergence with fixed sleeps (metric-based polling in CI).
+2. Surface adaptive metrics in interop reports (not just console JSON on failure).
+3. Run **fixed vs heuristic A/B** in-process and compare outcomes.
+4. Exercise **12 / 24 / 50 nodes** on a nightly schedule without bloating PR CI time.
+
+Tier 2 (Docker Compose) and the bandit scheduler stay out of scope until Tier 1 nightly runs pass reliably.
+
+---
+
+## Current state (post PR #36)
+
+### What works
+
+| Asset | Location | Notes |
+|-------|----------|-------|
+| Late-joiner convergence (fixed interval) | `simulateAntiEntropyConvergence` | Default 6 nodes, sleep-based wait |
+| Late-joiner convergence (adaptive) | Same + `adaptive` in `WorkerDataConfig` | Test in `interOpTestRunner.dataSync.int.ts` |
+| Strict polling hook | `ADAPTIVE_INTEROP_STRICT` env | Only affects late-joiner scenario today |
+| Worker anti-entropy snapshot | `nodeWorkerData.ts` → `getStatistics` | `outboundAttempts`, `usefulSyncs`, `lastSyncHashes`, `idleSkips` |
+| Dormant-room bench (no P2P) | `tests/perf/antiEntropyScheduler.bench.ts` | Unit-level scheduling A/B |
+| PR CI | `.github/workflows/ci.yaml` | `test:int:data-sync`, 45 min timeout, 6 GB heap |
+
+### Gaps to close
+
+| Gap | Evidence | Tier 1 fix |
+|-----|----------|------------|
+| CI uses sleep, not strict poll | `ci.yaml` has no `ADAPTIVE_INTEROP_STRICT` | Set env on data-sync job |
+| Reports omit anti-entropy | `interopTestReporter.ts` prints connections only | Extend `TestReport` + `printTestReport` |
+| Incomplete snapshot | `AntiEntropyMetricsStore.snapshot()` has more fields than worker exports | Extend worker + types |
+| `scheduledTicks` not counted | `recordScheduledTickStarted()` is a no-op stub | Implement counter in store |
+| No `convergenceMs` | Not tracked anywhere in interop | Worker or orchestrator timing |
+| No fixed vs heuristic interop A/B | Only separate unit bench | New scenario + nightly test |
+| Scale not exercised | Default 6 nodes; no nightly matrix | `interop-scale-nightly.yml` |
+| Split-brain / revival use sleeps only | `ANTI_ENTROPY_WAIT_MS` fixed delays | Generalized poll helpers |
+
+### Timing budget (late-joiner, 6 nodes)
+
+From `InterOpScenarios.ts` — understand before changing CI timeouts:
+
+| Phase | Duration | Purpose |
+|-------|----------|---------|
+| `STABILIZE_MS` | 120 s | Producer mesh + GossipSub replication topic subscriptions |
+| `REPLICATE_SETTLE_MS` | 30 s | Messages replicate across producers |
+| `LATE_JOINER_CONNECT_MS` | 20 s | Late joiner dials mesh |
+| `ANTI_ENTROPY_WAIT_MS` | `syncIntervalMs * 4 + 15s` = **75 s** (at 15s interval) | Sleep fallback |
+| Strict poll timeout | 120 s | `pollLateJoinerConvergence` max wait |
+
+**Worst-case wall time (strict):** ~120 + 30 + 20 + 120 ≈ **4.5 min** for adaptive test alone. Full `test:int:data-sync` suite has 6+ scenarios — keep PR CI at 45 min; monitor after enabling strict.
+
+---
+
+## Architecture (unchanged)
+
+```
+interOpTestRunner.*.int.ts          ← test entrypoints (node:test)
+        │
+        ▼
+InterOpScenarios.ts                 ← choreography (delays, spawn order, polls)
+        │
+        ├── workerUtils.ts          ← createWorker, terminateWorkers
+        │
+        └── childThread/
+              nodeWorkerData.js     ← real DeChat node per worker thread
+```
+
+**Constraint:** Production default `adaptive.enabled: false` must not change. All adaptive config is test-only via `WorkerDataConfig.adaptive`.
+
+---
+
+## Implementation plan
+
+### Phase 1 — Metrics foundation (small production touch)
+
+**Why first:** Worker snapshot and reports depend on store fields that do not exist yet.
+
+#### 1.1 Implement `scheduledTickCount` in `AntiEntropyMetricsStore`
+
+- File: `packages/core/src/data-convergence/scheduling/AntiEntropyMetricsStore.ts`
+- Change `recordScheduledTickStarted()` from no-op to `this.scheduledTickCount++`
+- Add `scheduledTicks: number` to `AntiEntropyMetricsSnapshot` and `snapshot()` return
+- Unit test: `AntiEntropyManager` or store unit test asserts tick count increments on `performScheduledSync` entry (including idle skips)
+
+#### 1.2 Export additional snapshot fields to interop (no new store logic)
+
+Already in `snapshot()` — wire through worker only:
+
+| Field | Source | Interop name |
+|-------|--------|--------------|
+| `skipCounts.floor_sync_forced` | store | `floorSyncForces` |
+| `skipCounts.mutex` | store | `mutexSkips` (optional, debug) |
+| `consecutiveZeroHashComplete` | store | `zeroHashStreak` |
+| `scheduledTicks` | store (new) | `scheduledTicks` |
+| `stateVector[5]` | store | `activityScore` (optional shorthand) |
+
+**Files:**
+
+- `packages/core/tests/interop/types.ts` — extend `WorkerResult.antiEntropy`
+- `packages/core/tests/interop/childThread/nodeWorkerData.ts` — map snapshot → result
+
+#### 1.3 Track `convergenceMs` on late joiner
+
+**Option A (recommended — worker-local):**
+
+In `nodeWorkerData.ts`:
+
+- On `set_expected_hashes` message: set `convergenceWatchStartedAt = Date.now()`
+- In `getStatistics`: if `usefulSyncs > 0` and `convergenceWatchStartedAt` set, expose `convergenceMs = Date.now() - convergenceWatchStartedAt` (cap at poll window)
+- Reset watch on message receipt
+
+**Option B (orchestrator):** `pollLateJoinerConvergence` returns elapsed ms — less accurate (includes poll interval granularity).
+
+Use **Option A** for per-node truth; orchestrator can also log wall-clock for A/B comparison.
+
+---
+
+### Phase 2 — Interop reporting
+
+#### 2.1 Extend report types
+
+File: `packages/core/tests/interop/types.ts`
+
+```typescript
+export type AntiEntropyInteropSummary = {
+  readonly lateJoiner?: WorkerResult['antiEntropy'] & { readonly convergenceMs?: number };
+  readonly producerIdleSkipsTotal: number;
+  readonly producerOutboundAttemptsTotal: number;
+  readonly producerFloorSyncForcesTotal: number;
+};
+
+export interface TestReport {
+  // ...existing fields...
+  readonly antiEntropy?: AntiEntropyInteropSummary;
+  readonly scenarioWallMs?: number; // for A/B timing
+}
+```
+
+#### 2.2 Add `summarizeAntiEntropyMetrics(workerResults)`
+
+File: `packages/core/tests/interop/interopTestReporter.ts` (or new `antiEntropyInteropSummary.ts`)
+
+- Identify late joiner: `hasTargetData !== undefined`
+- Identify producers: everyone else with `dataSyncEnabled` context
+- Aggregate producer `idleSkips`, `outboundAttempts`, `floorSyncForces`
+- Return `AntiEntropyInteropSummary`
+
+#### 2.3 Update `generateTestReport` / `printTestReport`
+
+Print section when `antiEntropy` present:
+
+```
+--- Anti-Entropy Metrics ---
+  Late joiner usefulSyncs: 2
+  Late joiner convergenceMs: 34120
+  Late joiner idleSkips: 0
+  Producer idleSkips (total): 18
+  Producer outboundAttempts (total): 45
+  Producer floorSyncForces (total): 3
+```
+
+#### 2.4 Optional JSON artifact (nightly)
+
+- Env: `INTEROP_WRITE_REPORT_JSON=true`
+- Write: `packages/core/tests/interop/reports/<test-name>-<timestamp>.json`
+- Add `reports/.gitkeep`; gitignore `reports/*.json` (artifacts uploaded from CI, not committed)
+
+---
+
+### Phase 3 — Strict polling in CI
+
+#### 3.1 Generalize poll helpers
+
+File: `packages/core/tests/interop/InterOpScenarios.ts` (or extract `interopPolling.ts`)
+
+| Helper | Trigger | Success condition | Used by |
+|--------|---------|-------------------|---------|
+| `pollLateJoinerUsefulSync` | existing | `usefulSyncs > 0` | Late joiner (adaptive + fixed strict) |
+| `pollWorkerTargetData` | new | `hasTargetData === true` | Split-brain, revival |
+| `pollAllWorkersTargetData` | new | all workers `hasTargetData` | Split-brain union |
+
+Shared implementation:
+
+```typescript
+const pollWorkerStats = async (
+  workerRef: Worker,
+  predicate: (stats: WorkerResult) => boolean,
+  intervalMs: number,
+  timeoutMs: number,
+): Promise<{ converged: boolean; elapsedMs: number }>
+```
+
+- Return `converged: false` on timeout (test asserts separately — don't hang CI silently)
+- Log warning on timeout with last snapshot
+
+#### 3.2 Enable strict mode in PR CI
+
+File: `.github/workflows/ci.yaml` — `integration-tests-data-sync` job:
+
+```yaml
+env:
+  NODE_OPTIONS: "--max-old-space-size=6144"
+  ADAPTIVE_INTEROP_STRICT: "true"
+```
+
+**Rollout:** Start with adaptive late-joiner only (already gated in scenario). After stable, extend strict polling to split-brain + revival in Phase 5.
+
+#### 3.3 Apply strict polling to adaptive late-joiner (verify)
+
+Existing code path at line ~327 in `InterOpScenarios.ts` — confirm:
+
+- When strict + timeout without `usefulSyncs`, late-joiner test fails with metrics in log
+- When strict + success, skip `ANTI_ENTROPY_WAIT_MS` sleep entirely
+
+**Optional improvement:** Also poll `hasTargetData` (stronger than `usefulSyncs > 0` alone) — late joiner may have useful sync then still miss hashes. Change success predicate to:
+
+```typescript
+stats?.hasTargetData === true
+```
+
+---
+
+### Phase 4 — Fixed vs heuristic A/B scenario
+
+#### 4.1 Scenario design
+
+**New export:** `simulateAntiEntropyConvergenceAbComparison(config)`  
+Or two sequential calls from test — prefer **single orchestrator** that returns structured comparison:
+
+```typescript
+export type AbComparisonResult = {
+  readonly fixed: AggregatedResult & { readonly wallMs: number };
+  readonly heuristic: AggregatedResult & { readonly wallMs: number };
+};
+```
+
+**Execution order:** Fixed first, then heuristic (same process, sequential — avoids port conflicts). Use distinct `networkId` suffixes: `benchnet-fixed-ab`, `benchnet-heuristic-ab` to prevent cross-talk if workers linger.
+
+**Shared parameters:**
+
+```typescript
+const baseConfig = {
+  testType: 'REPLICATION',
+  replicationType: 'TOPIC_BASED',
+  dataSyncEnabled: true,
+  syncIntervalMs: 15_000,
+  totalNodes: 6, // override via CLI for nightly
+  // ...messageRate, pubsubTopic, etc.
+};
+```
+
+| Run | `adaptive` |
+|-----|------------|
+| Fixed | `{ enabled: false }` |
+| Heuristic | `{ enabled: true, scheduler: 'heuristic', minIntervalMs: 5_000, maxIntervalMs: 60_000 }` |
+
+#### 4.2 Assertions (nightly test, not PR gate initially)
+
+File: `interOpTestRunner.dataSync.int.ts`
+
+```typescript
+it('should A/B compare fixed vs heuristic anti-entropy convergence', { skip: !process.env.INTEROP_AB_TEST }, async () => { ... });
+```
+
+Or separate file: `interOpTestRunner.adaptiveAb.int.ts` included only in nightly workflow.
+
+**Must pass (both runs):**
+
+- Late joiner `hasTargetData === true`
+- Late joiner `replicaCount >= maxProducerReplicaCount`
+- Late joiner `usefulSyncs > 0`
+
+**Heuristic-specific (soft → hard over time):**
+
+- At least one producer: `idleSkips > 0` after late joiner converged (poll producers once more before terminate)
+- Report `scenarioWallMs` for both — **do not fail** if heuristic slower initially; log ratio in report
+
+**Comparison report section:**
+
+```
+--- A/B Comparison ---
+  Fixed wallMs: 290000
+  Heuristic wallMs: 275000
+  Heuristic producer idleSkips: 24 vs Fixed: 0
+  Heuristic producer outboundAttempts: 12 vs Fixed: 28
+```
+
+#### 4.3 Dormant-phase idle skip assertion
+
+After late joiner converges, wait `maxIntervalMs / 2` (or 30s min), poll all producers:
+
+- Heuristic: expect `sum(idleSkips) >= 1`
+- Fixed: expect `sum(idleSkips) === 0` (or undefined)
+
+This validates the adaptive policy in a **live P2P** setting, not just the bench simulation.
+
+---
+
+### Phase 5 — Strict polling for split-brain and revival
+
+#### 5.1 Split-brain (`simulateSplitBrainConvergence`)
+
+Replace final `await delay(ANTI_ENTROPY_WAIT_MS)` when `ADAPTIVE_INTEROP_STRICT`:
+
+```typescript
+if (ADAPTIVE_INTEROP_STRICT) {
+  await pollAllWorkersTargetData(workers, 180_000);
+} else {
+  await delay(ANTI_ENTROPY_WAIT_MS);
+}
+```
+
+Timeout: 180s (heal + sync takes longer than late-joiner).
+
+#### 5.2 Offline revival (`simulateOfflinePeerRevivalConvergence`)
+
+Replace final sleep with `pollWorkerTargetData(revivedWorker, 180_000)`.
+
+#### 5.3 PR CI scope decision
+
+| Scenario | Strict in PR CI? | Recommendation |
+|----------|------------------|----------------|
+| Late joiner (adaptive) | Yes | Phase 3 |
+| Late joiner (fixed) | Optional | Keep sleep for now (less critical) |
+| Split-brain | Phase 5b | Enable after 1 week green nightly |
+| Revival | Phase 5b | Enable after 1 week green nightly |
+
+---
+
+### Phase 6 — Nightly scale workflow
+
+#### 6.1 New workflow file
+
+`.github/workflows/interop-scale-nightly.yml`
+
+```yaml
+on:
+  schedule:
+    - cron: '0 3 * * *'  # 03:00 UTC daily
+  workflow_dispatch:
+
+jobs:
+  adaptive-scale-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        nodes: [12, 24, 50]
+    steps:
+      # checkout, node, yarn install, yarn build (same as ci.yaml)
+      - name: Adaptive late-joiner scale run
+        env:
+          NODE_OPTIONS: "--max-old-space-size=6144"
+          ADAPTIVE_INTEROP_STRICT: "true"
+          INTEROP_WRITE_REPORT_JSON: "true"
+        run: |
+          yarn workspace @dechat/core test:int:data-sync -- \
+            --test-name-pattern "adaptive heuristic" \
+            --nodes ${{ matrix.nodes }}
+
+      - name: Upload interop report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: interop-report-nodes-${{ matrix.nodes }}
+          path: packages/core/tests/interop/reports/
+
+  adaptive-ab-nightly:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      # ... build ...
+      - name: Fixed vs heuristic A/B
+        env:
+          NODE_OPTIONS: "--max-old-space-size=6144"
+          ADAPTIVE_INTEROP_STRICT: "true"
+          INTEROP_AB_TEST: "true"
+          INTEROP_WRITE_REPORT_JSON: "true"
+        run: yarn workspace @dechat/core test:int:adaptive-ab  # new script
+```
+
+**Note:** `node:test` filter syntax may need adjustment — verify how `readInteropCliArgs` parses `--nodes`. May require dedicated entry script `interOpTestRunner.adaptiveScale.int.ts` that only runs adaptive + A/B tests.
+
+#### 6.2 New package.json scripts
+
+```json
+"test:int:adaptive-ab": "NODE_ENV=perf LOG_LEVEL=INFO node --trace-warnings dist/tests/interop/interOpTestRunner.adaptiveAb.int.js",
+"test:int:adaptive-scale": "NODE_ENV=perf LOG_LEVEL=INFO node --trace-warnings dist/tests/interop/interOpTestRunner.adaptiveScale.int.js"
+```
+
+Keep `test:int:data-sync` unchanged for PR CI (full suite).
+
+#### 6.3 Scale timing estimates
+
+| Nodes | STABILIZE risk | Suggested timeout |
+|-------|----------------|-------------------|
+| 12 | Low | 45 min job |
+| 24 | Medium — mesh formation | 60 min job |
+| 50 | High — GossipSub subscribe pressure | 90 min job; may need `STABILIZE_MS` scale factor |
+
+**Future optimization (not Phase 6 v1):** `STABILIZE_MS = base + (totalNodes - 6) * 5000` — only if 50-node flakes.
+
+---
+
+### Phase 7 — Documentation
+
+Create `packages/core/tests/interop/README.md`:
+
+- Env vars table (`ADAPTIVE_INTEROP_STRICT`, `INTEROP_AB_TEST`, `INTEROP_WRITE_REPORT_JSON`)
+- Local commands (build-first rule)
+- PR CI vs nightly CI scope
+- How to read anti-entropy report section
+- Troubleshooting flakes (mesh not formed → increase stabilize; worker leak → check terminate)
+
+---
+
+## File change matrix
+
+| File | Phase | Action |
+|------|-------|--------|
+| `AntiEntropyMetricsStore.ts` | 1 | `scheduledTickCount` |
+| `AntiEntropyMetricsStore.unit.test.ts` or manager test | 1 | Tick count assertion |
+| `tests/interop/types.ts` | 1–2 | Extended `antiEntropy`, `TestReport` |
+| `tests/interop/childThread/nodeWorkerData.ts` | 1 | Snapshot + `convergenceMs` |
+| `tests/interop/interopTestReporter.ts` | 2 | Summary + print |
+| `tests/interop/interopPolling.ts` | 3 | **New** — shared poll helpers |
+| `tests/interop/InterOpScenarios.ts` | 3–5 | Use polls; A/B orchestrator |
+| `tests/interop/interOpTestRunner.dataSync.int.ts` | 3 | Pass anti-entropy summary to report |
+| `tests/interop/interOpTestRunner.adaptiveAb.int.ts` | 4 | **New** — A/B test only |
+| `tests/interop/interOpTestRunner.adaptiveScale.int.ts` | 6 | **New** — adaptive tests only |
+| `.github/workflows/ci.yaml` | 3 | `ADAPTIVE_INTEROP_STRICT=true` |
+| `.github/workflows/interop-scale-nightly.yml` | 6 | **New** |
+| `packages/core/package.json` | 6 | New scripts |
+| `tests/interop/README.md` | 7 | **New** |
+| `tests/interop/reports/.gitkeep` | 2 | **New** |
+| `.gitignore` | 2 | `packages/core/tests/interop/reports/*.json` |
+| `BACKLOG.md` | — | Link to this doc |
+| `tasks/todo.md` | — | Link to this doc |
+
+---
+
+## CI strategy summary
+
+```mermaid
+flowchart TB
+  subgraph pr["PR CI (every push to develop)"]
+    U[unit tests]
+    S[test:int:startup]
+    D[test:int:data-sync<br/>ADAPTIVE_INTEROP_STRICT=true]
+    U --> S
+    U --> D
+  end
+
+  subgraph nightly["Nightly CI (cron)"]
+    M12[nodes=12 adaptive]
+    M24[nodes=24 adaptive]
+    M50[nodes=50 adaptive]
+    AB[fixed vs heuristic A/B]
+  end
+
+  pr -.->|validates correctness| nightly
+```
+
+| Gate | Runs | Strict poll | A/B | Max nodes |
+|------|------|-------------|-----|-----------|
+| PR | Full data-sync suite | Yes (late joiner adaptive) | No | 6 |
+| Nightly | Adaptive + A/B only | Yes | Yes | 12, 24, 50 |
+
+---
+
+## Acceptance criteria
+
+### PR merge gate (Tier 1 complete for PR)
+
+- [ ] `yarn workspace @dechat/core test` — all unit tests pass
+- [ ] `yarn build && yarn test:int:data-sync` with `ADAPTIVE_INTEROP_STRICT=true` — green
+- [ ] Adaptive late-joiner report prints anti-entropy section with `usefulSyncs`, `convergenceMs`, `idleSkips`
+- [ ] `scheduledTicks` increments in store (unit tested)
+- [ ] No change to `adaptive.enabled` default in `config/defaults.ts`
+
+### Nightly gate (Tier 1 fully complete)
+
+- [ ] `interop-scale-nightly.yml` green for matrix 12 / 24 / 50
+- [ ] A/B test: both modes converge; heuristic `producerIdleSkipsTotal >= 1`
+- [ ] JSON artifacts uploaded; no worker-thread hang (all workers terminate)
+- [ ] 7 consecutive nightly greens before starting bandit scheduler work
+
+---
+
+## Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Strict poll flakes on slow CI | Medium | 120s timeout; log last snapshot; keep sleep fallback env off in CI only after soak |
+| 50-node mesh never forms | High | Nightly only; start with 12; scale STABILIZE_MS if needed |
+| A/B doubles wall time | Low (nightly only) | Separate workflow job, not in PR |
+| `usefulSyncs > 0` but `hasTargetData false` | Low | Poll on `hasTargetData` as primary success signal |
+| Worker leak on timeout | Medium | `terminateWorkers` in `finally`; existing interop teardown rules |
+| `recordScheduledTickStarted` behavior change | Low | Counter only; no scheduling logic change |
+
+---
+
+## Out of scope (Tier 1)
+
+- Docker Compose interop (Tier 2 — `tasks/tier2-compose-interop.md` TBD)
+- Bandit scheduler implementation
+- Testground
+- Changing production adaptive defaults
+- Cross-version libp2p interop
+- Dynamic `STABILIZE_MS` formula (defer unless 50-node flakes)
+
+---
+
+## Implementation checklist (execution order)
+
+Use this as the PR sequence — one or more PRs per phase is fine.
+
+### PR 1 — Metrics + reporting (Phases 1–2)
+
+- [ ] 1.1 `scheduledTickCount` in store + unit test
+- [ ] 1.2 Extended `WorkerResult.antiEntropy` + worker snapshot mapping
+- [ ] 1.3 `convergenceMs` on late joiner (`set_expected_hashes` watch)
+- [ ] 2.1–2.3 `summarizeAntiEntropyMetrics` + report printing
+- [ ] 2.4 JSON artifact + `.gitkeep` + gitignore
+- [ ] Verify: unit tests + manual `test:int:data-sync` (strict off)
+
+### PR 2 — Strict CI polling (Phase 3)
+
+- [ ] 3.1 Extract `interopPolling.ts`
+- [ ] 3.2 Change poll success to `hasTargetData === true`
+- [ ] 3.3 `ADAPTIVE_INTEROP_STRICT=true` in `ci.yaml`
+- [ ] Verify: full data-sync CI green
+
+### PR 3 — A/B + extended scenarios (Phases 4–5)
+
+- [ ] 4.1 `simulateAntiEntropyConvergenceAbComparison`
+- [ ] 4.2 `interOpTestRunner.adaptiveAb.int.ts` + package script
+- [ ] 4.3 Dormant-phase producer idle skip assertion
+- [ ] 5.1–5.2 Strict poll for split-brain + revival
+- [ ] Verify: local A/B run with `INTEROP_AB_TEST=true`
+
+### PR 4 — Nightly CI + docs (Phases 6–7)
+
+- [ ] 6.1 `interop-scale-nightly.yml`
+- [ ] 6.2 `interOpTestRunner.adaptiveScale.int.ts`
+- [ ] 7.1 `tests/interop/README.md`
+- [ ] Update `BACKLOG.md` Task 5.1 status → In progress / Done
+- [ ] Soak: monitor 7 nightly runs
+
+---
+
+## Approval
+
+**Pending your review.** Suggested starting point: **PR 1** (metrics + reporting) — zero CI risk, immediate observability win.
+
+After approval, begin with Phase 1.1 (`scheduledTickCount`).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -910,5 +910,15 @@ packages/core/tests/unit/data-convergence/scheduling/
 - [x] Step 3 — Scheduler refactor + fixed mode regression
 - [x] Step 4 — Heuristic peer pick + idle skip (Phase 1)
 - [x] Step 5 — Adaptive interval (Phase 2)
-- [ ] Step 6 — CI / interop verification (skipped locally; CI on PR)
+- [x] Step 6 — CI / interop verification (PR #36 green)
 - [ ] Step 7 — Bandit scheduler (optional)
+
+### Follow-up backlog (scale testing)
+
+Deferred Testground evaluation (see [libp2p/test-plans#103](https://github.com/libp2p/test-plans/issues/103)).
+
+| Task | Plan doc | Summary |
+|------|----------|---------|
+| **5.1 Tier 1** | [tasks/tier1-adaptive-interop.md](tier1-adaptive-interop.md) | Strict CI polling, richer metrics, fixed vs heuristic A/B, nightly 12/24/50-node runs — **implement next** |
+| **5.2 Tier 2** | TBD (`tasks/tier2-compose-interop.md`) | Docker Compose interop — after Tier 1 nightly green |
+| **Step 7 Bandit** | `todo.md` Step 7 | After Tier 1 nightly green (7 consecutive passes) |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -919,6 +919,6 @@ Deferred Testground evaluation (see [libp2p/test-plans#103](https://github.com/l
 
 | Task | Plan doc | Summary |
 |------|----------|---------|
-| **5.1 Tier 1** | [tasks/tier1-adaptive-interop.md](tier1-adaptive-interop.md) | Strict CI polling, richer metrics, fixed vs heuristic A/B, nightly 12/24/50-node runs — **implement next** |
+| **5.1 Tier 1** | [tasks/tier1-adaptive-interop.md](tier1-adaptive-interop.md) | PR #37 — PR gate complete (CI green); nightly 12/24/50 + A/B soak pending merge |
 | **5.2 Tier 2** | TBD (`tasks/tier2-compose-interop.md`) | Docker Compose interop — after Tier 1 nightly green |
 | **Step 7 Bandit** | `todo.md` Step 7 | After Tier 1 nightly green (7 consecutive passes) |


### PR DESCRIPTION
## Summary
- Implements Tier 1 from `tasks/tier1-adaptive-interop.md` (follow-up to merged PR #36): richer anti-entropy interop metrics, strict `hasTargetData` polling in PR CI, fixed vs heuristic A/B scenarios, and a nightly scale workflow for 12/24/50 nodes.
- Adds `scheduledTicks` to `AntiEntropyMetricsStore`, extends worker snapshots (`convergenceMs`, `floorSyncForces`, `idleSkips`, etc.), and surfaces them in interop test reports with optional JSON artifacts.
- Enables `ADAPTIVE_INTEROP_STRICT=true` on the data-sync CI job; nightly workflow runs adaptive scale matrix and A/B comparison separately from PR gates.

## Test plan
- [x] `yarn workspace @dechat/core test` — 141 unit tests pass
- [x] `yarn build && ADAPTIVE_INTEROP_STRICT=true yarn workspace @dechat/core test:int:data-sync` — full data-sync interop suite (CI)
- [x] Verify `integration-tests-data-sync` job passes with strict polling enabled
- [ ] After merge: monitor `interop-scale-nightly.yml` (cron 03:00 UTC) for 12/24/50-node matrix + A/B job
- [ ] Local optional: `INTEROP_AB_TEST=true ADAPTIVE_INTEROP_STRICT=true yarn workspace @dechat/core test:int:adaptive-ab`


Made with [Cursor](https://cursor.com)