### PR TITLE
feat(core): epsilon-greedy bandit anti-entropy scheduler (Step 7)

### DIFF
--- a/packages/core/src/data-convergence/scheduling/bandit/BanditSyncScheduler.ts
+++ b/packages/core/src/data-convergence/scheduling/bandit/BanditSyncScheduler.ts
@@ -1,0 +1,72 @@
+import { PeerId } from '@libp2p/interface';
+import { DeChatConfig } from '../../../config/types';
+import { AntiEntropyMetricsStore } from '../AntiEntropyMetricsStore';
+import { HeuristicSyncScheduler } from '../HeuristicSyncScheduler';
+import { SyncAttemptRecord, SyncScheduler, SyncTickContext } from '../types';
+import { DynamicArmSet } from './DynamicArmSet';
+import { EpsilonGreedyPolicy } from './EpsilonGreedyPolicy';
+import { computeSyncReward } from './RewardFunction';
+
+type AdaptiveConfig = DeChatConfig['strategies']['synchronizer']['adaptive'];
+
+const resolveBanditConfig = (
+  config: AdaptiveConfig,
+): {
+  readonly epsilon: number;
+  readonly epsilonDecayPerAttempts: number;
+  readonly epsilonFloor: number;
+} => ({
+  epsilon: config.bandit?.epsilon ?? 0.2,
+  epsilonDecayPerAttempts: config.bandit?.epsilonDecayPerAttempts ?? 0,
+  epsilonFloor: config.bandit?.epsilonFloor ?? 0.05,
+});
+
+/**
+ * ADR Phase 3 scheduler: epsilon-greedy MAB peer pick with heuristic interval + idle skip.
+ */
+export class BanditSyncScheduler implements SyncScheduler {
+  private readonly heuristic: HeuristicSyncScheduler;
+  private readonly armSet: DynamicArmSet;
+  private readonly policy: EpsilonGreedyPolicy;
+
+  constructor(config: AdaptiveConfig, metricsStore: AntiEntropyMetricsStore, policy?: EpsilonGreedyPolicy) {
+    this.heuristic = new HeuristicSyncScheduler(config, metricsStore.getPeerConvergenceTracker());
+    this.armSet = new DynamicArmSet(config.minPeerWeight);
+    this.policy = policy ?? new EpsilonGreedyPolicy(resolveBanditConfig(config));
+  }
+
+  pickPeer(candidates: readonly PeerId[]): PeerId {
+    const peerIds = candidates.map((peer) => peer.toString());
+    this.armSet.syncCandidates(peerIds);
+    const selectedId = this.policy.selectPeer(peerIds, this.armSet);
+    const selected = candidates.find((peer) => peer.toString() === selectedId);
+    if (!selected) {
+      throw new Error(`BanditSyncScheduler.pickPeer: selected peer ${selectedId} not in candidates`);
+    }
+    return selected;
+  }
+
+  shouldSkipTick(ctx: SyncTickContext): boolean {
+    return this.heuristic.shouldSkipTick(ctx);
+  }
+
+  nextIntervalMs(ctx: SyncTickContext): number {
+    return this.heuristic.nextIntervalMs(ctx);
+  }
+
+  onOutboundSyncComplete(record: SyncAttemptRecord): void {
+    this.armSet.recordReward(record.peerId, computeSyncReward(record));
+    this.policy.onAttemptComplete();
+    this.heuristic.onOutboundSyncComplete(record);
+  }
+
+  /** Exposed for tests */
+  getArmSnapshot(): ReturnType<DynamicArmSet['snapshot']> {
+    return this.armSet.snapshot();
+  }
+
+  /** Exposed for tests */
+  getEpsilon(): number {
+    return this.policy.getEpsilon();
+  }
+}

--- a/packages/core/src/data-convergence/scheduling/bandit/DynamicArmSet.ts
+++ b/packages/core/src/data-convergence/scheduling/bandit/DynamicArmSet.ts
@@ -1,0 +1,61 @@
+type ArmStats = {
+  pulls: number;
+  totalReward: number;
+};
+
+/**
+ * Per-peer bandit arms with churn-safe pruning.
+ * New peers start with optimistic prior reward = minPeerWeight so they stay reachable.
+ */
+export class DynamicArmSet {
+  private readonly arms = new Map<string, ArmStats>();
+
+  constructor(private readonly minPeerWeight: number) {}
+
+  /** Drop arms for disconnected peers; ensure every candidate has an arm */
+  syncCandidates(candidatePeerIds: readonly string[]): void {
+    const active = new Set(candidatePeerIds);
+
+    for (const peerId of this.arms.keys()) {
+      if (!active.has(peerId)) {
+        this.arms.delete(peerId);
+      }
+    }
+
+    for (const peerId of candidatePeerIds) {
+      if (!this.arms.has(peerId)) {
+        this.arms.set(peerId, { pulls: 0, totalReward: 0 });
+      }
+    }
+  }
+
+  /** Average reward for an arm; unexplored arms return optimistic minPeerWeight */
+  getAverageReward(peerId: string): number {
+    const arm = this.arms.get(peerId);
+    if (!arm || arm.pulls === 0) {
+      return this.minPeerWeight;
+    }
+    return arm.totalReward / arm.pulls;
+  }
+
+  recordReward(peerId: string, reward: number): void {
+    const arm = this.arms.get(peerId);
+    if (!arm) {
+      return;
+    }
+    arm.pulls++;
+    arm.totalReward += reward;
+  }
+
+  /** Snapshot for tests and debug */
+  snapshot(): ReadonlyMap<string, { readonly pulls: number; readonly averageReward: number }> {
+    const result = new Map<string, { pulls: number; averageReward: number }>();
+    for (const [peerId, arm] of this.arms) {
+      result.set(peerId, {
+        pulls: arm.pulls,
+        averageReward: arm.pulls === 0 ? this.minPeerWeight : arm.totalReward / arm.pulls,
+      });
+    }
+    return result;
+  }
+}

--- a/packages/core/src/data-convergence/scheduling/bandit/EpsilonGreedyPolicy.ts
+++ b/packages/core/src/data-convergence/scheduling/bandit/EpsilonGreedyPolicy.ts
@@ -1,0 +1,75 @@
+import { pickRandom } from '@dechat/common';
+import { DynamicArmSet } from './DynamicArmSet';
+
+export type EpsilonGreedyConfig = {
+  readonly epsilon: number;
+  readonly epsilonDecayPerAttempts: number;
+  readonly epsilonFloor: number;
+};
+
+const DECAY_MULTIPLIER = 0.95;
+
+/**
+ * Epsilon-greedy peer selection over dynamic bandit arms.
+ * Explores uniformly; exploits highest average reward with random tie-break.
+ */
+export class EpsilonGreedyPolicy {
+  private currentEpsilon: number;
+  private attemptCount = 0;
+
+  constructor(
+    private readonly config: EpsilonGreedyConfig,
+    private readonly random: () => number = Math.random,
+    private readonly pickRandomFn: typeof pickRandom = pickRandom,
+  ) {
+    this.currentEpsilon = config.epsilon;
+  }
+
+  /** Select a peer ID from candidates using epsilon-greedy over arm averages */
+  selectPeer(candidatePeerIds: readonly string[], armSet: DynamicArmSet): string {
+    if (candidatePeerIds.length === 0) {
+      throw new Error('EpsilonGreedyPolicy.selectPeer: candidates cannot be empty');
+    }
+    if (candidatePeerIds.length === 1) {
+      return candidatePeerIds[0];
+    }
+
+    if (this.random() < this.currentEpsilon) {
+      return this.pickRandomFn([...candidatePeerIds]).item;
+    }
+
+    let bestReward = Number.NEGATIVE_INFINITY;
+    const bestPeers: string[] = [];
+
+    for (const peerId of candidatePeerIds) {
+      const reward = armSet.getAverageReward(peerId);
+      if (reward > bestReward) {
+        bestReward = reward;
+        bestPeers.length = 0;
+        bestPeers.push(peerId);
+      } else if (reward === bestReward) {
+        bestPeers.push(peerId);
+      }
+    }
+
+    return this.pickRandomFn(bestPeers).item;
+  }
+
+  /** Record a completed attempt and optionally anneal exploration rate */
+  onAttemptComplete(): void {
+    this.attemptCount++;
+
+    const { epsilonDecayPerAttempts, epsilonFloor } = this.config;
+    if (epsilonDecayPerAttempts <= 0) {
+      return;
+    }
+
+    if (this.attemptCount % Math.round(epsilonDecayPerAttempts) === 0) {
+      this.currentEpsilon = Math.max(epsilonFloor, this.currentEpsilon * DECAY_MULTIPLIER);
+    }
+  }
+
+  getEpsilon(): number {
+    return this.currentEpsilon;
+  }
+}

--- a/packages/core/src/data-convergence/scheduling/bandit/RewardFunction.ts
+++ b/packages/core/src/data-convergence/scheduling/bandit/RewardFunction.ts
@@ -1,0 +1,25 @@
+import { SyncAttemptRecord } from '../types';
+
+/** Expected hash bucket for partial-sync reward normalization (no version vectors in DeChat) */
+const PARTIAL_EXPECTED_HASHES = 10;
+
+/**
+ * DeChat-adapted Bengfort-style reward for epsilon-greedy peer selection.
+ * Distinguishes converged complete syncs (0 hashes, +0.1) from failed attempts (0).
+ */
+export const computeSyncReward = (record: SyncAttemptRecord): number => {
+  const { result } = record;
+
+  if (result.kind === 'failed') {
+    return 0;
+  }
+
+  if (result.kind === 'complete') {
+    if (result.hashesDiscovered > 0) {
+      return 0.5 + 0.1 * Math.min(1, result.hashesDiscovered / PARTIAL_EXPECTED_HASHES);
+    }
+    return 0.1;
+  }
+
+  return 0.05 * (result.hashesDiscovered / Math.max(1, PARTIAL_EXPECTED_HASHES));
+};

--- a/packages/core/src/data-convergence/scheduling/index.ts
+++ b/packages/core/src/data-convergence/scheduling/index.ts
@@ -1,5 +1,6 @@
 import { DeChatConfig } from '../../config/types';
 import { AntiEntropyMetricsStore } from './AntiEntropyMetricsStore';
+import { BanditSyncScheduler } from './bandit/BanditSyncScheduler';
 import { FixedSyncScheduler } from './FixedSyncScheduler';
 import { HeuristicSyncScheduler } from './HeuristicSyncScheduler';
 import { SyncScheduler } from './types';
@@ -30,14 +31,14 @@ export const createSyncScheduler = (
     );
   }
 
-  // Bandit scheduler (Phase 3) not yet implemented — fall back to heuristic
-  return new HeuristicSyncScheduler(
-    { ...adaptive, maxIntervalMs: resolveMaxIntervalMs(config) },
-    metricsStore.getPeerConvergenceTracker(),
-  );
+  return new BanditSyncScheduler({ ...adaptive, maxIntervalMs: resolveMaxIntervalMs(config) }, metricsStore);
 };
 
 export { AntiEntropyMetricsStore, createAntiEntropyMetricsStore } from './AntiEntropyMetricsStore';
+export { BanditSyncScheduler } from './bandit/BanditSyncScheduler';
+export { DynamicArmSet } from './bandit/DynamicArmSet';
+export { EpsilonGreedyPolicy } from './bandit/EpsilonGreedyPolicy';
+export { computeSyncReward } from './bandit/RewardFunction';
 export { FixedSyncScheduler } from './FixedSyncScheduler';
 export { HeuristicSyncScheduler } from './HeuristicSyncScheduler';
 export { PeerConvergenceTracker } from './PeerConvergenceTracker';

--- a/packages/core/tests/unit/data-convergence/AntiEntropyManager.adaptive.unit.test.ts
+++ b/packages/core/tests/unit/data-convergence/AntiEntropyManager.adaptive.unit.test.ts
@@ -233,4 +233,19 @@ describe('AntiEntropyManager (adaptive scheduling)', () => {
     manager.stop();
     vi.mocked(Math.random).mockRestore();
   });
+
+  it('runs scheduled syncs with bandit scheduler mode', async () => {
+    const { manager, mockExchange } = buildManager(adaptiveSynchronizerConfig({ scheduler: 'bandit' }), [
+      { remotePeer: peer('peer-1') },
+      { remotePeer: peer('peer-2') },
+    ]);
+    manager.start();
+
+    await (manager as any).performScheduledSync();
+
+    expect(mockExchange.syncWithPeer).toHaveBeenCalledTimes(1);
+    expect(debugSpy.mock.calls.some(([m]) => String(m).includes('mode=bandit'))).toBe(true);
+
+    manager.stop();
+  });
 });

--- a/packages/core/tests/unit/data-convergence/scheduling/bandit/BanditSyncScheduler.unit.test.ts
+++ b/packages/core/tests/unit/data-convergence/scheduling/bandit/BanditSyncScheduler.unit.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DECHAT_DEFAULTS } from '../../../../../src/config/defaults';
+import { createAntiEntropyMetricsStore } from '../../../../../src/data-convergence/scheduling/AntiEntropyMetricsStore';
+import { BanditSyncScheduler } from '../../../../../src/data-convergence/scheduling/bandit/BanditSyncScheduler';
+import { EpsilonGreedyPolicy } from '../../../../../src/data-convergence/scheduling/bandit/EpsilonGreedyPolicy';
+import { SyncTickContext } from '../../../../../src/data-convergence/scheduling/types';
+
+const adaptiveConfig = {
+  ...DECHAT_DEFAULTS.strategies.synchronizer.adaptive,
+  enabled: true,
+  scheduler: 'bandit' as const,
+};
+
+const mockPeer = (id: string) => ({ toString: () => id }) as never;
+
+const tickContext = (overrides: Partial<SyncTickContext> = {}): SyncTickContext => ({
+  now: Date.now(),
+  timeSinceLastSyncMs: 0,
+  timeSinceLastUsefulSyncMs: 0,
+  consecutiveZeroHashComplete: 0,
+  stateVector: [1, 0, 0, 0, 0, 0, 0],
+  forceFloorSync: false,
+  ...overrides,
+});
+
+describe('BanditSyncScheduler', () => {
+  it('delegates idle skip and interval to the heuristic scheduler', () => {
+    const metricsStore = createAntiEntropyMetricsStore(DECHAT_DEFAULTS.strategies.synchronizer);
+    const scheduler = new BanditSyncScheduler(adaptiveConfig, metricsStore);
+
+    const ctx = tickContext({
+      consecutiveZeroHashComplete: adaptiveConfig.idleSkipStreak,
+      stateVector: [1, 0, 0, 0, 0, 0, 0],
+    });
+
+    expect(scheduler.shouldSkipTick(ctx)).toBe(true);
+    expect(scheduler.nextIntervalMs(tickContext())).toBeGreaterThan(0);
+  });
+
+  it('updates arm rewards after outbound sync completion', () => {
+    const metricsStore = createAntiEntropyMetricsStore(DECHAT_DEFAULTS.strategies.synchronizer);
+    const policy = new EpsilonGreedyPolicy(
+      { epsilon: 0, epsilonDecayPerAttempts: 0, epsilonFloor: 0.05 },
+      () => 1,
+      (items) => ({ item: items[0], index: 0 }),
+    );
+    const scheduler = new BanditSyncScheduler(adaptiveConfig, metricsStore, policy);
+
+    scheduler.pickPeer([mockPeer('peer-a'), mockPeer('peer-b')]);
+    scheduler.onOutboundSyncComplete({
+      peerId: 'peer-a',
+      startedAt: Date.now(),
+      durationMs: 50,
+      result: { kind: 'complete', hashesDiscovered: 10, durationMs: 50 },
+    });
+
+    const snapshot = scheduler.getArmSnapshot().get('peer-a');
+    expect(snapshot?.pulls).toBe(1);
+    expect(snapshot?.averageReward).toBeCloseTo(0.6);
+  });
+
+  it('is created by createSyncScheduler when scheduler is bandit', async () => {
+    const { createSyncScheduler } = await import('../../../../../src/data-convergence/scheduling');
+    const metricsStore = createAntiEntropyMetricsStore({
+      ...DECHAT_DEFAULTS.strategies.synchronizer,
+      adaptive: { ...adaptiveConfig, scheduler: 'bandit' },
+    });
+
+    const scheduler = createSyncScheduler(
+      {
+        ...DECHAT_DEFAULTS.strategies.synchronizer,
+        adaptive: { ...adaptiveConfig, scheduler: 'bandit' },
+      },
+      metricsStore,
+    );
+
+    expect(scheduler).toBeInstanceOf(BanditSyncScheduler);
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
+    const picked = scheduler.pickPeer([mockPeer('peer-a'), mockPeer('peer-b')]);
+    expect(['peer-a', 'peer-b']).toContain(picked.toString());
+    vi.mocked(Math.random).mockRestore();
+  });
+});

--- a/packages/core/tests/unit/data-convergence/scheduling/bandit/DynamicArmSet.unit.test.ts
+++ b/packages/core/tests/unit/data-convergence/scheduling/bandit/DynamicArmSet.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { DynamicArmSet } from '../../../../../src/data-convergence/scheduling/bandit/DynamicArmSet';
+
+describe('DynamicArmSet', () => {
+  it('prunes arms when peers disconnect', () => {
+    const armSet = new DynamicArmSet(0.1);
+    armSet.syncCandidates(['peer-a', 'peer-b']);
+    armSet.recordReward('peer-a', 0.5);
+    armSet.syncCandidates(['peer-b']);
+
+    expect(armSet.snapshot().has('peer-a')).toBe(false);
+    expect(armSet.snapshot().has('peer-b')).toBe(true);
+  });
+
+  it('returns optimistic prior for unexplored arms', () => {
+    const armSet = new DynamicArmSet(0.1);
+    armSet.syncCandidates(['new-peer']);
+    expect(armSet.getAverageReward('new-peer')).toBe(0.1);
+  });
+
+  it('tracks running average reward per arm', () => {
+    const armSet = new DynamicArmSet(0.1);
+    armSet.syncCandidates(['peer-a']);
+    armSet.recordReward('peer-a', 0.6);
+    armSet.recordReward('peer-a', 0.2);
+
+    expect(armSet.getAverageReward('peer-a')).toBeCloseTo(0.4);
+  });
+});

--- a/packages/core/tests/unit/data-convergence/scheduling/bandit/EpsilonGreedyPolicy.unit.test.ts
+++ b/packages/core/tests/unit/data-convergence/scheduling/bandit/EpsilonGreedyPolicy.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DynamicArmSet } from '../../../../../src/data-convergence/scheduling/bandit/DynamicArmSet';
+import { EpsilonGreedyPolicy } from '../../../../../src/data-convergence/scheduling/bandit/EpsilonGreedyPolicy';
+
+describe('EpsilonGreedyPolicy', () => {
+  it('exploits the highest-reward arm when random draw is above epsilon', () => {
+    const armSet = new DynamicArmSet(0.1);
+    armSet.syncCandidates(['good-peer', 'bad-peer']);
+    armSet.recordReward('good-peer', 0.8);
+    armSet.recordReward('bad-peer', 0.1);
+
+    const policy = new EpsilonGreedyPolicy(
+      { epsilon: 0.2, epsilonDecayPerAttempts: 0, epsilonFloor: 0.05 },
+      () => 0.9,
+      (items) => ({ item: items[0], index: 0 }),
+    );
+
+    expect(policy.selectPeer(['good-peer', 'bad-peer'], armSet)).toBe('good-peer');
+  });
+
+  it('explores uniformly when random draw is below epsilon', () => {
+    const armSet = new DynamicArmSet(0.1);
+    armSet.syncCandidates(['peer-a', 'peer-b']);
+    armSet.recordReward('peer-a', 0.9);
+    armSet.recordReward('peer-b', 0.1);
+
+    const policy = new EpsilonGreedyPolicy(
+      { epsilon: 0.5, epsilonDecayPerAttempts: 0, epsilonFloor: 0.05 },
+      () => 0.1,
+      (items) => ({ item: items[1], index: 1 }),
+    );
+
+    expect(policy.selectPeer(['peer-a', 'peer-b'], armSet)).toBe('peer-b');
+  });
+
+  it('anneals epsilon after configured attempt intervals', () => {
+    const policy = new EpsilonGreedyPolicy({
+      epsilon: 0.2,
+      epsilonDecayPerAttempts: 2,
+      epsilonFloor: 0.05,
+    });
+
+    policy.onAttemptComplete();
+    expect(policy.getEpsilon()).toBe(0.2);
+
+    policy.onAttemptComplete();
+    expect(policy.getEpsilon()).toBeCloseTo(0.19);
+  });
+});

--- a/packages/core/tests/unit/data-convergence/scheduling/bandit/RewardFunction.unit.test.ts
+++ b/packages/core/tests/unit/data-convergence/scheduling/bandit/RewardFunction.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { computeSyncReward } from '../../../../../src/data-convergence/scheduling/bandit/RewardFunction';
+import { SyncAttemptRecord } from '../../../../../src/data-convergence/scheduling/types';
+
+const record = (result: SyncAttemptRecord['result']): SyncAttemptRecord => ({
+  peerId: 'peer-1',
+  startedAt: Date.now(),
+  durationMs: 50,
+  result,
+});
+
+describe('computeSyncReward', () => {
+  it('returns 0 for failed syncs', () => {
+    expect(computeSyncReward(record({ kind: 'failed', durationMs: 50 }))).toBe(0);
+  });
+
+  it('returns 0.1 for converged complete syncs with zero hashes', () => {
+    expect(computeSyncReward(record({ kind: 'complete', hashesDiscovered: 0, durationMs: 50 }))).toBe(0.1);
+  });
+
+  it('scales useful complete sync rewards up to 0.6', () => {
+    expect(computeSyncReward(record({ kind: 'complete', hashesDiscovered: 5, durationMs: 50 }))).toBe(0.55);
+    expect(computeSyncReward(record({ kind: 'complete', hashesDiscovered: 10, durationMs: 50 }))).toBe(0.6);
+    expect(computeSyncReward(record({ kind: 'complete', hashesDiscovered: 20, durationMs: 50 }))).toBe(0.6);
+  });
+
+  it('gives partial credit for incomplete syncs', () => {
+    expect(computeSyncReward(record({ kind: 'partial', hashesDiscovered: 5, durationMs: 50, reason: 'timeout' }))).toBe(
+      0.025,
+    );
+  });
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -790,9 +790,9 @@ Execute in sequence; tests must stay green at each step.
 
 ### Step 7 — Phase 3 bandit (optional, separate PR)
 
-- [ ] `RewardFunction`, `EpsilonGreedyPolicy`, `BanditSyncScheduler`
-- [ ] `scheduler: 'bandit'` config
-- [ ] Interop A/B report in `tests/perf/reports/`
+- [x] `RewardFunction`, `EpsilonGreedyPolicy`, `BanditSyncScheduler`, `DynamicArmSet`
+- [x] `scheduler: 'bandit'` wired in `createSyncScheduler`
+- [ ] Interop A/B report in `tests/perf/reports/` (defer until nightly soak complete)
 - [ ] Update ADR or add ADR-0004 if ONNX pursued
 
 ---
@@ -911,7 +911,7 @@ packages/core/tests/unit/data-convergence/scheduling/
 - [x] Step 4 — Heuristic peer pick + idle skip (Phase 1)
 - [x] Step 5 — Adaptive interval (Phase 2)
 - [x] Step 6 — CI / interop verification (PR #36 green)
-- [ ] Step 7 — Bandit scheduler (optional)
+- [x] Step 7 — Bandit scheduler (PR pending nightly soak before merge)
 
 ### Follow-up backlog (scale testing)
 
@@ -921,4 +921,4 @@ Deferred Testground evaluation (see [libp2p/test-plans#103](https://github.com/l
 |------|----------|---------|
 | **5.1 Tier 1** | [tasks/tier1-adaptive-interop.md](tier1-adaptive-interop.md) | PR #37 — PR gate complete (CI green); nightly 12/24/50 + A/B soak pending merge |
 | **5.2 Tier 2** | TBD (`tasks/tier2-compose-interop.md`) | Docker Compose interop — after Tier 1 nightly green |
-| **Step 7 Bandit** | `todo.md` Step 7 | After Tier 1 nightly green (7 consecutive passes) |
+| **Step 7 Bandit** | `todo.md` Step 7 | Implementation in PR — merge after Tier 1 nightly soak (7 consecutive passes) |


### PR DESCRIPTION
## Summary
- Implements Phase 3 `BanditSyncScheduler` with epsilon-greedy peer selection over a dynamic arm set
- Adds `RewardFunction` (DeChat-adapted Bengfort-style rewards), `EpsilonGreedyPolicy`, and `DynamicArmSet` (churn-safe arm pruning)
- Bandit delegates **interval** and **idle-skip** policy to `HeuristicSyncScheduler` — only peer pick is MAB-driven
- Wires `scheduler: 'bandit'` in `createSyncScheduler` (config already existed in types/defaults)

## Merge gate
**Do not merge until Tier 1 nightly soak completes (7 consecutive greens).** Currently **1/7** after [run #2](https://github.com/Ahmed-Abdul-Rahman/de-chat/actions/runs/28585662815).

## Design notes
| Signal | Reward |
|--------|--------|
| `complete` + hashes > 0 | `0.5 + 0.1 × min(1, hashes/10)` |
| `complete` + hashes === 0 | `0.1` (converged) |
| `partial` | `0.05 × (hashes / 10)` |
| `failed` | `0` |

New peers get optimistic prior = `minPeerWeight` (0.1). Arms pruned when peers disconnect.

## Test plan
- [x] `vitest run tests/unit/data-convergence/scheduling/bandit/**` (13 tests)
- [x] `AntiEntropyManager.adaptive.unit.test.ts` — bandit mode smoke test
- [x] Full core unit suite (157 tests)
- [x] `yarn build`
- [x] CI unit + integration (PR workflow)
- [ ] Merge after 7/7 nightly greens

## Deferred
- Interop A/B bandit vs heuristic perf report (`tests/perf/reports/`)
- ADR update for bandit (optional)


Made with [Cursor](https://cursor.com)