### PR TITLE
fix(interop): extend nightly timing headroom (assertions unchanged)

### DIFF
--- a/.github/workflows/interop-scale-nightly.yml
+++ b/.github/workflows/interop-scale-nightly.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   adaptive-scale-matrix:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # 50-node scenario can exceed 25m wall with scaled stabilize/poll headroom
+    timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:

--- a/packages/core/tests/interop/README.md
+++ b/packages/core/tests/interop/README.md
@@ -44,7 +44,9 @@ When data sync is enabled, reports include:
 ## Troubleshooting
 
 - **Mesh not formed:** `computeMeshStabilizeMs` in `interopTiming.ts` scales stabilize/replicate windows with node count
-- **Strict poll timeout:** scales via `computeLateJoinerPollTimeoutMs`; check worker logs and `set_expected_hashes` ordering
+- **Strict poll timeout:** scales via `computeLateJoinerPollTimeoutMs` (50-node poll is 560s); check worker logs and `set_expected_hashes` ordering
 - **Worker hang:** ensure `terminateWorkers` runs; integration tests must clean up all worker threads
+
+Timing helpers only extend wait/poll windows. Scale assertions still require `hasTargetData`, producer-sized `replicaCount`, and `usefulSyncs > 0`.
 
 Late-joiner scenarios defer gossip replication ingest until `set_expected_hashes`, then dial producers explicitly (no mDNS) so convergence is attributed to anti-entropy rather than live gossip during connect.

--- a/packages/core/tests/interop/interopTiming.ts
+++ b/packages/core/tests/interop/interopTiming.ts
@@ -1,15 +1,18 @@
 /** Base mesh stabilize time proven at 6 nodes in interop scenarios */
 const BASE_MESH_STABILIZE_MS = 120_000;
-const MESH_STABILIZE_PER_NODE_MS = 5_000;
+const MESH_STABILIZE_PER_NODE_MS = 6_000;
 const BASE_MESH_NODE_COUNT = 6;
 
 const BASE_REPLICATE_SETTLE_MS = 30_000;
-const REPLICATE_SETTLE_PER_NODE_MS = 2_000;
+const REPLICATE_SETTLE_PER_NODE_MS = 3_000;
 
 const BASE_LATE_JOINER_POLL_MS = 120_000;
-const LATE_JOINER_POLL_PER_NODE_MS = 5_000;
+/** Headroom for CI load; 50-node runs have converged near 335s and timed out at 340s */
+const LATE_JOINER_POLL_PER_NODE_MS = 10_000;
 
 const PRODUCER_CONSENSUS_POLL_MS = 5_000;
+const BASE_PRODUCER_CONSENSUS_EXTRA_MS = 90_000;
+const PRODUCER_CONSENSUS_PER_NODE_MS = 5_000;
 
 /** GossipSub mesh formation time scales with producer count */
 export const computeMeshStabilizeMs = (totalNodes: number): number =>
@@ -22,7 +25,7 @@ export const computeReplicateSettleMs = (totalNodes: number): number =>
 /** Strict poll window for late-joiner hasTargetData; scales with node count and sync interval */
 export const computeLateJoinerPollTimeoutMs = (totalNodes: number, syncIntervalMs: number): number =>
   Math.max(
-    syncIntervalMs * 8 + 30_000,
+    syncIntervalMs * 12 + 60_000,
     BASE_LATE_JOINER_POLL_MS + Math.max(0, totalNodes - BASE_MESH_NODE_COUNT) * LATE_JOINER_POLL_PER_NODE_MS,
   );
 
@@ -31,4 +34,5 @@ export const computeProducerConsensusPollMs = (): number => PRODUCER_CONSENSUS_P
 
 /** Timeout for producer replica-count consensus before collecting expected hashes */
 export const computeProducerConsensusTimeoutMs = (totalNodes: number): number =>
-  computeReplicateSettleMs(totalNodes) + Math.max(60_000, (totalNodes - BASE_MESH_NODE_COUNT) * 3_000);
+  computeReplicateSettleMs(totalNodes) +
+  Math.max(BASE_PRODUCER_CONSENSUS_EXTRA_MS, (totalNodes - BASE_MESH_NODE_COUNT) * PRODUCER_CONSENSUS_PER_NODE_MS);

--- a/packages/core/tests/unit/interop/interopTiming.unit.test.ts
+++ b/packages/core/tests/unit/interop/interopTiming.unit.test.ts
@@ -10,14 +10,20 @@ describe('interopTiming', () => {
   it('keeps base timings at 6 nodes', () => {
     expect(computeMeshStabilizeMs(6)).toBe(120_000);
     expect(computeReplicateSettleMs(6)).toBe(30_000);
-    expect(computeLateJoinerPollTimeoutMs(6, 15_000)).toBe(150_000);
-    expect(computeProducerConsensusTimeoutMs(6)).toBe(90_000);
+    expect(computeLateJoinerPollTimeoutMs(6, 15_000)).toBe(240_000);
+    expect(computeProducerConsensusTimeoutMs(6)).toBe(120_000);
   });
 
-  it('scales mesh and poll windows for large clusters', () => {
-    expect(computeMeshStabilizeMs(50)).toBe(340_000);
-    expect(computeReplicateSettleMs(50)).toBe(118_000);
-    expect(computeLateJoinerPollTimeoutMs(50, 15_000)).toBe(340_000);
-    expect(computeProducerConsensusTimeoutMs(50)).toBe(250_000);
+  it('scales mesh and poll windows for large clusters with CI headroom', () => {
+    // 50-node late-joiner poll must exceed observed borderline convergence (~335s)
+    expect(computeMeshStabilizeMs(50)).toBe(384_000);
+    expect(computeReplicateSettleMs(50)).toBe(162_000);
+    expect(computeLateJoinerPollTimeoutMs(50, 15_000)).toBe(560_000);
+    expect(computeProducerConsensusTimeoutMs(50)).toBe(382_000);
+  });
+
+  it('does not reduce 6-node PR-CI minimums below anti-entropy tick budget', () => {
+    // At least 12 sync intervals + 60s so usefulSyncs can accumulate under load
+    expect(computeLateJoinerPollTimeoutMs(6, 15_000)).toBeGreaterThanOrEqual(15_000 * 12 + 60_000);
   });
 });


### PR DESCRIPTION
## Summary
- Extends interop timing windows only — **no assertion or metric changes**
- Scale tests still require `hasTargetData`, producer-sized `replicaCount`, and `usefulSyncs > 0`
- Addresses intermittent 50-node poll timeouts where convergence completed near 335s and the old 340s ceiling failed under CI load

## Timing changes (50 nodes)

| Window | Before | After |
|--------|--------|-------|
| Mesh stabilize | 340s | 384s |
| Replicate settle | 118s | 162s |
| Producer consensus | 250s | 382s |
| Late-joiner strict poll | 340s | **560s** |
| Nightly job timeout | 120m | 150m |

6-node PR CI also gets a slightly longer minimum poll (`syncIntervalMs * 12 + 60s` = 240s) so anti-entropy ticks have more room under load — same success criteria.

## Explicitly not changed
- `assertLateJoinerConvergence` defaults (`requireUsefulSync: true` on scale)
- A/B idle-skip comparison
- Production adaptive defaults

## Test plan
- [x] `vitest run tests/unit/interop/interopTiming.unit.test.ts`
- [ ] PR CI unit tests
- [ ] Re-run `interop-scale-nightly` via workflow_dispatch after merge


Made with [Cursor](https://cursor.com)