### PR TITLE
fix(interop): gate replication-protocol passive ingest on late joiner

### DIFF
--- a/packages/core/tests/interop/README.md
+++ b/packages/core/tests/interop/README.md
@@ -49,4 +49,4 @@ When data sync is enabled, reports include:
 
 Timing helpers only extend wait/poll windows. Scale assertions still require `hasTargetData`, producer-sized `replicaCount`, and `usefulSyncs > 0`.
 
-Late-joiner scenarios defer gossip replication ingest until `set_expected_hashes`, then dial producers explicitly (no mDNS) so convergence is attributed to anti-entropy rather than live gossip during connect.
+Late-joiner scenarios defer all passive replication ingest (gossip, direct, and replication-protocol announce/content) for the worker's lifetime when `suppressReplicationIngest` is set. `set_expected_hashes` only starts the convergence clock; anti-entropy's explicit `requestMissingData` path is the sole ingest route so `usefulSyncs > 0` reflects real sync work.

--- a/packages/core/tests/interop/childThread/nodeWorkerData.ts
+++ b/packages/core/tests/interop/childThread/nodeWorkerData.ts
@@ -12,6 +12,7 @@ import { PeerExchangeService } from '../../../src/networking/PeerExchangeService
 import { ReplicaStoreInterface } from '../../../src/replica-store/ReplicaStoreInterface';
 import { WireCodec } from '../../../src/shared/serialization/types';
 import { WorkerData, WorkerResult } from '../types';
+import { installReplicationProtocolIngestGate } from './replicationIngestGate';
 import { configureNode, percentile } from './workerUitls';
 
 type GossipMessageA = { message: string };
@@ -298,12 +299,17 @@ const runNodeDataReplication = async () => {
   wireSerializer = engine.serializer;
   antiEntropyMetrics = engine.antiEntropyMetrics;
 
-  let replicationIngestEnabled = !args.suppressReplicationIngest;
+  const passiveReplicationSuppressed = args.suppressReplicationIngest === true;
+  let replicationIngestEnabled = !passiveReplicationSuppressed;
 
   const ingestRemoteData = async <T>(data: T, fromPeer: string): Promise<void> => {
     if (!replicationIngestEnabled) return;
     await dataReplication.onRemoteDataReceived(data, fromPeer);
   };
+
+  if (passiveReplicationSuppressed) {
+    installReplicationProtocolIngestGate(dataReplication, () => replicationIngestEnabled);
+  }
 
   await engine.start();
 
@@ -404,7 +410,10 @@ const runNodeDataReplication = async () => {
       targetHashesToFetch = message.hashes;
       convergenceWatchStartedAt = Date.now();
       convergenceMsRecorded = null;
-      replicationIngestEnabled = true;
+      // Late-joiner harness keeps passive ingest disabled so only anti-entropy fills the store.
+      if (!passiveReplicationSuppressed) {
+        replicationIngestEnabled = true;
+      }
     } else if (message.type === 'terminate') {
       terminateThread = true;
       await terminateAndCleanUp(node, broadcastProp, engine.nodeCleanUp, replicaStore);

--- a/packages/core/tests/interop/childThread/replicationIngestGate.ts
+++ b/packages/core/tests/interop/childThread/replicationIngestGate.ts
@@ -1,0 +1,29 @@
+import type { DataReplicationInterface } from '../../../src/data-replication/DataReplicationInterface';
+import type { ReplicationEngineDelegate } from '../../../src/data-replication/replication-protocol/ReplicationEngineDelegateInterface';
+
+/**
+ * Wraps the replication-protocol delegate so passive announce/content ingest can be
+ * deferred independently of anti-entropy's explicit `requestMissingData` fetches.
+ */
+export const installReplicationProtocolIngestGate = (
+  dataReplication: DataReplicationInterface,
+  isIngestEnabled: () => boolean,
+): void => {
+  const delegate = dataReplication as unknown as ReplicationEngineDelegate;
+
+  dataReplication.replicationProtocol.setDelegate({
+    onPeerAnnounced: async (hash, peerId, handleAnnounce) => {
+      if (!isIngestEnabled()) return;
+      return delegate.onPeerAnnounced(hash, peerId, handleAnnounce);
+    },
+    onPeerRequested: (hash, fromPeerId) => delegate.onPeerRequested(hash, fromPeerId),
+    onPeerDeliveredContent: async (hash, data, peerId) => {
+      if (!isIngestEnabled()) return;
+      return delegate.onPeerDeliveredContent(hash, data, peerId);
+    },
+    onPeerReportedError: async (hash, reason, closestPeers, peerId) => {
+      if (!isIngestEnabled()) return;
+      return delegate.onPeerReportedError(hash, reason, closestPeers, peerId);
+    },
+  });
+};

--- a/packages/core/tests/unit/interop/replicationIngestGate.unit.test.ts
+++ b/packages/core/tests/unit/interop/replicationIngestGate.unit.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DataReplicationInterface } from '../../../src/data-replication/DataReplicationInterface';
+import type { ReplicationEngineDelegate } from '../../../src/data-replication/replication-protocol/ReplicationEngineDelegateInterface';
+import { installReplicationProtocolIngestGate } from '../../interop/childThread/replicationIngestGate';
+
+const createMockDelegate = (): ReplicationEngineDelegate => ({
+  onPeerAnnounced: vi.fn().mockResolvedValue(undefined),
+  onPeerRequested: vi.fn().mockResolvedValue({ found: false, closestPeers: [] }),
+  onPeerDeliveredContent: vi.fn().mockResolvedValue(undefined),
+  onPeerReportedError: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('installReplicationProtocolIngestGate', () => {
+  it('blocks passive announce and content ingest while the gate is closed', async () => {
+    const inner = createMockDelegate();
+    let wrapped: ReplicationEngineDelegate | undefined;
+    const dataReplication = {
+      replicationProtocol: {
+        setDelegate: (delegate: ReplicationEngineDelegate) => {
+          wrapped = delegate;
+        },
+      },
+    } as unknown as DataReplicationInterface;
+
+    Object.assign(dataReplication, inner);
+
+    const ingestEnabled = false;
+    installReplicationProtocolIngestGate(dataReplication, () => ingestEnabled);
+    expect(wrapped).toBeDefined();
+
+    const handleAnnounce = vi.fn().mockResolvedValue(undefined);
+    await wrapped!.onPeerAnnounced('hash-a', 'peer-1', handleAnnounce);
+    await wrapped!.onPeerDeliveredContent('hash-b', new Uint8Array([1]), 'peer-2');
+    await wrapped!.onPeerReportedError('hash-c', 'not_found', [], 'peer-3');
+
+    expect(inner.onPeerAnnounced).not.toHaveBeenCalled();
+    expect(handleAnnounce).not.toHaveBeenCalled();
+    expect(inner.onPeerDeliveredContent).not.toHaveBeenCalled();
+    expect(inner.onPeerReportedError).not.toHaveBeenCalled();
+  });
+
+  it('forwards passive ingest once the gate opens but always serves peer requests', async () => {
+    const inner = createMockDelegate();
+    let wrapped: ReplicationEngineDelegate | undefined;
+    const dataReplication = {
+      replicationProtocol: {
+        setDelegate: (delegate: ReplicationEngineDelegate) => {
+          wrapped = delegate;
+        },
+      },
+    } as unknown as DataReplicationInterface;
+
+    Object.assign(dataReplication, inner);
+
+    const ingestEnabled = true;
+    installReplicationProtocolIngestGate(dataReplication, () => ingestEnabled);
+
+    const handleAnnounce = vi.fn().mockResolvedValue(undefined);
+    await wrapped!.onPeerAnnounced('hash-a', 'peer-1', handleAnnounce);
+    await wrapped!.onPeerRequested('hash-d', 'peer-4');
+
+    expect(inner.onPeerAnnounced).toHaveBeenCalledWith('hash-a', 'peer-1', handleAnnounce);
+    expect(inner.onPeerRequested).toHaveBeenCalledWith('hash-d', 'peer-4');
+  });
+});


### PR DESCRIPTION
## Summary
- Wraps the replication-protocol delegate in interop workers when `suppressReplicationIngest` is set, blocking passive `onPeerAnnounced` / `onPeerDeliveredContent` ingest
- Stops re-enabling passive ingest on `set_expected_hashes` for late-joiner harness workers so only anti-entropy `requestMissingData` can populate the store
- Fixes the `usefulSyncs: 0` flake where the late joiner converged in ~1ms via replication-protocol passive fetch while assertions still required `usefulSyncs > 0`

## Test plan
- [x] `yarn workspace @dechat/core test packages/core/tests/unit/interop/replicationIngestGate.unit.test.ts`
- [ ] Manual `workflow_dispatch` on Interop Scale Nightly (12/24/50)
- [ ] Confirm scheduled nightly #20+ passes 24-node scale job


Made with [Cursor](https://cursor.com)