### PR TITLE
feat(interop): Compose late-joiner harness for Tier 2 (PR B)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Used by packages/core/tests/compose-interop Docker builds (context = repo root).
+**/node_modules
+**/dist
+**/.git
+**/coverage
+**/.cursor
+**/agent-transcripts
+tasks
+apps/backend/src
+packages/blockchain/src
+packages/examples
+*.md
+!packages/core/tests/compose-interop/README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,8 @@
 tasks
 apps/backend/src
 packages/blockchain/src
-packages/examples
+# Keep workspace package.json files for yarn install; drop unused sources only.
+packages/examples/**
+!packages/examples/package.json
 *.md
 !packages/core/tests/compose-interop/README.md

--- a/.github/workflows/compose-interop.yml
+++ b/.github/workflows/compose-interop.yml
@@ -1,0 +1,85 @@
+# Tier 2 Compose interop — runs Dockerized late-joiner on GitHub-hosted runners.
+# Path-filtered on PRs so unrelated changes stay on the fast worker-thread CI gate.
+name: Compose Interop
+
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - 'packages/core/tests/compose-interop/**'
+      - 'packages/core/tests/interop/nodeRunner.ts'
+      - 'packages/core/tests/interop/childThread/workerUitls.ts'
+      - 'packages/core/tests/interop/types.ts'
+      - 'packages/core/package.json'
+      - '.github/workflows/compose-interop.yml'
+      - '.dockerignore'
+  workflow_dispatch:
+    inputs:
+      compose_nodes:
+        description: 'Total nodes (producers + 1 late joiner)'
+        required: false
+        default: '7'
+      adaptive_enabled:
+        description: 'ADAPTIVE_ENABLED'
+        required: false
+        default: 'true'
+
+concurrency:
+  group: compose-interop-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  late-joiner-lan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable Corepack (Yarn 4)
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build packages
+        run: yarn build
+
+      - name: Docker availability
+        run: |
+          docker version
+          docker compose version
+
+      - name: Compose late-joiner (lan)
+        env:
+          COMPOSE_NODES: ${{ github.event.inputs.compose_nodes || '7' }}
+          ADAPTIVE_ENABLED: ${{ github.event.inputs.adaptive_enabled || 'true' }}
+          SCHEDULER: heuristic
+          SYNC_INTERVAL_MS: '15000'
+          NODE_OPTIONS: '--max-old-space-size=6144'
+        run: yarn workspace @dechat/core test:compose:late-joiner
+
+      - name: Upload Compose reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: compose-late-joiner-lan
+          path: packages/core/tests/compose-interop/reports/
+          if-no-files-found: ignore
+
+      - name: Teardown Compose leftovers
+        if: always()
+        run: |
+          for i in $(seq 0 31); do docker rm -f "dechat-node-${i}" >/dev/null 2>&1 || true; done
+          docker compose -p dechat-compose-interop \
+            -f packages/core/tests/compose-interop/docker-compose.yml \
+            down -v --remove-orphans || true

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -199,7 +199,7 @@ The core architecture has successfully transitioned to a robust, Dependency-Inje
 > **Implementation plan:** [tasks/tier2-compose-interop.md](tasks/tier2-compose-interop.md) — groomed checklist, phased PRs, approval gate.
 
 * **Severity:** Medium–High (realistic P2P conditions; catches bugs invisible on localhost worker threads)
-* **Status:** **Active** — plan ready for approval (2026-07-16); Tier 1 + Bandit closed
+* **Status:** **Active** — PR A merged (#42); PR B in progress (`feat/tier2-compose-late-joiner`)
 * **Depends on:** Task 5.1 — **done**
 * **Goal:** Run the same DeChat convergence scenarios in **isolated containers** with configurable network conditions (latency, jitter, bandwidth, partitions), following the pattern libp2p adopted after leaving Testground.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "test:int:adaptive-ab": "NODE_ENV=perf LOG_LEVEL=INFO node --trace-warnings dist/tests/interop/interOpTestRunner.adaptiveAb.int.js",
     "test:int:adaptive-scale": "NODE_ENV=perf LOG_LEVEL=INFO node --trace-warnings dist/tests/interop/interOpTestRunner.adaptiveScale.int.js",
     "test:int:narrow": "NODE_ENV=perf LOG_LEVEL=INFO node --trace-warnings dist/tests/interop/interOpTestRunner.startup.int.js --nodes 3 --duration 30",
+    "test:compose:late-joiner": "bash tests/compose-interop/scripts/run-scenario.sh",
     "sim": "NODE_ENV=perf node dist/tests/interop/initiateTest.js --nodes 3 --duration 30",
     "sim:peak": "NODE_OPTIONS='--max-old-space-size=4096' NODE_ENV=perf node dist/tests/interop/SimulateMultiNode.int.js --nodes 50 --duration 1500"
   },
@@ -53,6 +54,7 @@
     "level": "^8.0.0",
     "libp2p": "^2.5.0",
     "lru-cache": "^11.2.4",
+    "redis": "^6.1.0",
     "type-fest": "^5.6.0"
   },
   "devDependencies": {

--- a/packages/core/tests/compose-interop/Dockerfile
+++ b/packages/core/tests/compose-interop/Dockerfile
@@ -1,0 +1,42 @@
+# DeChat Compose interop node image — builds workspace packages needed by @dechat/core.
+FROM node:22-bookworm-slim AS build
+
+WORKDIR /app
+
+RUN corepack enable
+
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn/ ./.yarn/
+COPY packages/common/package.json ./packages/common/
+COPY packages/crypto/package.json ./packages/crypto/
+COPY packages/core/package.json ./packages/core/
+
+# Placeholder workspace packages so yarn install resolves the monorepo graph.
+COPY packages/blockchain/package.json ./packages/blockchain/
+COPY packages/examples/package.json ./packages/examples/
+COPY apps/backend/package.json ./apps/backend/
+
+RUN yarn install --immutable
+
+COPY packages/common ./packages/common
+COPY packages/crypto ./packages/crypto
+COPY packages/core ./packages/core
+COPY tsconfig.json ./
+
+RUN yarn workspace @dechat/common build \
+  && yarn workspace @dechat/crypto build \
+  && yarn workspace @dechat/core build
+
+FROM node:22-bookworm-slim AS runtime
+
+WORKDIR /app
+ENV NODE_ENV=perf
+ENV LOG_LEVEL=INFO
+
+COPY --from=build /app /app
+
+WORKDIR /app/packages/core
+
+EXPOSE 4001
+
+CMD ["node", "dist/tests/compose-interop/composeNodeMain.js"]

--- a/packages/core/tests/compose-interop/Dockerfile
+++ b/packages/core/tests/compose-interop/Dockerfile
@@ -25,6 +25,9 @@ COPY packages/crypto ./packages/crypto
 COPY packages/core ./packages/core
 COPY tsconfig.json ./
 
+# Root-hoisted bins (tsc-alias, etc.) are not on PATH under workspace hoistingLimits.
+ENV PATH="/app/node_modules/.bin:${PATH}"
+
 RUN yarn workspace @dechat/common build \
   && yarn workspace @dechat/crypto build \
   && yarn workspace @dechat/core build

--- a/packages/core/tests/compose-interop/Dockerfile
+++ b/packages/core/tests/compose-interop/Dockerfile
@@ -7,6 +7,8 @@ RUN corepack enable
 
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY .yarn/ ./.yarn/
+# Root postinstall runs scanMalware → scripts/shai-hulud-scan.js
+COPY scripts ./scripts
 COPY packages/common/package.json ./packages/common/
 COPY packages/crypto/package.json ./packages/crypto/
 COPY packages/core/package.json ./packages/core/
@@ -16,10 +18,7 @@ COPY packages/blockchain/package.json ./packages/blockchain/
 COPY packages/examples/package.json ./packages/examples/
 COPY apps/backend/package.json ./apps/backend/
 
-# Skip workspace lifecycle scripts (root postinstall malware scan needs scripts/ not in image).
-# Rebuild native addons core needs after skip-build.
-RUN yarn install --immutable --mode=skip-build \
-  && yarn rebuild classic-level cbor-extract esbuild
+RUN yarn install --immutable
 
 COPY packages/common ./packages/common
 COPY packages/crypto ./packages/crypto

--- a/packages/core/tests/compose-interop/Dockerfile
+++ b/packages/core/tests/compose-interop/Dockerfile
@@ -16,7 +16,10 @@ COPY packages/blockchain/package.json ./packages/blockchain/
 COPY packages/examples/package.json ./packages/examples/
 COPY apps/backend/package.json ./apps/backend/
 
-RUN yarn install --immutable
+# Skip workspace lifecycle scripts (root postinstall malware scan needs scripts/ not in image).
+# Rebuild native addons core needs after skip-build.
+RUN yarn install --immutable --mode=skip-build \
+  && yarn rebuild classic-level cbor-extract esbuild
 
 COPY packages/common ./packages/common
 COPY packages/crypto ./packages/crypto

--- a/packages/core/tests/compose-interop/README.md
+++ b/packages/core/tests/compose-interop/README.md
@@ -6,9 +6,20 @@ Reuses `nodeRunner` from worker-thread interop via a Redis transport. Tier 1 wor
 
 ## Prerequisites
 
-- Docker 24+ with Compose v2
+- Docker 24+ with Compose v2 (local) **or** GitHub Actions (`Compose Interop` workflow)
 - Repo built: `yarn workspace @dechat/core build` (orchestrator runs on the host from `dist/`)
-- Free host port `6379` (Redis)
+- Free host port `6379` (Redis) when running locally
+
+## CI (no local Docker required)
+
+Workflow: [`.github/workflows/compose-interop.yml`](../../../../.github/workflows/compose-interop.yml)
+
+| Trigger | When |
+|---------|------|
+| `pull_request` | Changes under `compose-interop/` / `nodeRunner` / this workflow (path-filtered) |
+| `workflow_dispatch` | Manual run from Actions tab (optional `compose_nodes`) |
+
+On PR #43 (and future Compose PRs), open the **Compose Interop** check — it builds the image on `ubuntu-latest`, runs `test:compose:late-joiner`, uploads `reports/` artifacts, and tears down containers.
 
 ## Quick start — late joiner (lan)
 

--- a/packages/core/tests/compose-interop/README.md
+++ b/packages/core/tests/compose-interop/README.md
@@ -1,0 +1,64 @@
+# Compose interop (Tier 2)
+
+Multi-container DeChat convergence tests using Docker Compose + Redis barriers.
+
+Reuses `nodeRunner` from worker-thread interop via a Redis transport. Tier 1 worker interop remains the PR CI gate; Compose is for realistic TCP / later netem profiles.
+
+## Prerequisites
+
+- Docker 24+ with Compose v2
+- Repo built: `yarn workspace @dechat/core build` (orchestrator runs on the host from `dist/`)
+- Free host port `6379` (Redis)
+
+## Quick start — late joiner (lan)
+
+From repo root:
+
+```bash
+yarn workspace @dechat/core build
+yarn workspace @dechat/core test:compose:late-joiner
+```
+
+Defaults: **6 producers + 1 late joiner**, `adaptive.enabled=true`, `scheduler=heuristic`.
+
+Overrides:
+
+```bash
+COMPOSE_NODES=7 \
+ADAPTIVE_ENABLED=true \
+SCHEDULER=heuristic \
+SYNC_INTERVAL_MS=15000 \
+yarn workspace @dechat/core test:compose:late-joiner
+```
+
+## What the script does
+
+1. Builds the Compose node image
+2. Starts Redis
+3. Starts `dechat-node-0…N-1` on the Compose network (`ADVERTISE_HOST=dechat-node-{i}`)
+4. Runs the host orchestrator (`scenarios/late-joiner-adaptive.ts`)
+5. Tears down containers + volumes (`docker compose down -v`)
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `composeNodeMain.ts` | Container entry — Redis transport → `startNodeRunner` |
+| `composeOrchestrator.ts` | Host control plane (commands / barriers) |
+| `scenarios/late-joiner-adaptive.ts` | P0 late-joiner choreography |
+| `scripts/run-scenario.sh` | Docker lifecycle + orchestrator |
+| `reports/` | JSON reports (gitignored) |
+
+## Debugging
+
+```bash
+docker logs dechat-node-0
+docker compose -p dechat-compose-interop -f packages/core/tests/compose-interop/docker-compose.yml logs redis
+LOG_LEVEL=debug yarn workspace @dechat/core test:compose:late-joiner
+```
+
+## Out of scope (later PRs)
+
+- Netem `wan` / `lossy` (PR C)
+- Nightly GH Actions workflow (PR D)
+- Split-brain / partition heal (PR D)

--- a/packages/core/tests/compose-interop/composeKeys.ts
+++ b/packages/core/tests/compose-interop/composeKeys.ts
@@ -1,0 +1,10 @@
+/** Redis key helpers shared by Compose node entrypoint and orchestrator. */
+
+export const readyKey = (index: number): string => `ready:${index}`;
+export const addrsKey = (index: number): string => `addrs:${index}`;
+export const cmdKey = (index: number): string => `cmd:${index}`;
+export const evtKey = (index: number): string => `evt:${index}`;
+export const statsKey = (index: number): string => `stats:${index}`;
+
+export const BARRIER_PRODUCERS_MESH = 'barrier:producers-mesh';
+export const BARRIER_PRODUCERS_DONE = 'barrier:producers-done';

--- a/packages/core/tests/compose-interop/composeNodeMain.ts
+++ b/packages/core/tests/compose-interop/composeNodeMain.ts
@@ -1,3 +1,4 @@
+import { isIPv4 } from 'node:net';
 import { networkInterfaces } from 'node:os';
 import { logger } from '@dechat/common';
 import { createClient } from 'redis';
@@ -28,8 +29,7 @@ const detectAdvertiseHost = (fallback: string): string => {
 
   for (const addrs of Object.values(networkInterfaces())) {
     for (const addr of addrs ?? []) {
-      const family = typeof addr.family === 'string' ? addr.family : String(addr.family);
-      if ((family === 'IPv4' || family === '4') && !addr.internal) {
+      if (!addr.internal && isIPv4(addr.address)) {
         return addr.address;
       }
     }

--- a/packages/core/tests/compose-interop/composeNodeMain.ts
+++ b/packages/core/tests/compose-interop/composeNodeMain.ts
@@ -1,0 +1,114 @@
+import { logger } from '@dechat/common';
+import { createClient } from 'redis';
+import { type NodeRunnerOutboundMessage, type NodeRunnerTransport, startNodeRunner } from '../interop/nodeRunner';
+import type { WorkerData } from '../interop/types';
+import { addrsKey, cmdKey, readyKey, statsKey } from './composeKeys';
+import { createRedisNodeTransport } from './redisTransport';
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env ${name}`);
+  return value;
+};
+
+const optionalEnv = (name: string, fallback: string): string => process.env[name] ?? fallback;
+
+const parseBool = (value: string | undefined, fallback: boolean): boolean => {
+  if (value === undefined) return fallback;
+  return value === '1' || value.toLowerCase() === 'true';
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+process.on('unhandledRejection', (reason) => {
+  logger.warn(`[composeNode] Suppressed unhandledRejection: ${String(reason)}`);
+});
+
+const main = async (): Promise<void> => {
+  const index = Number(requireEnv('NODE_INDEX'));
+  const totalNodes = Number(requireEnv('TOTAL_NODES'));
+  const role = requireEnv('ROLE');
+  const redisUrl = requireEnv('REDIS_URL');
+  const listenPort = Number(optionalEnv('LISTEN_PORT', '4001'));
+  const advertiseHost = optionalEnv('ADVERTISE_HOST', `dechat-node-${index}`);
+  const networkId = optionalEnv('NETWORK_ID', 'compose-interop');
+  const pubsubTopic = optionalEnv('PUBSUB_TOPIC', '/dechat/compose/v1');
+  const nodeSeed = optionalEnv('NODE_SEED', `Compose-Node-${index}`);
+  const syncIntervalMs = Number(optionalEnv('SYNC_INTERVAL_MS', '15000'));
+  const adaptiveEnabled = parseBool(process.env.ADAPTIVE_ENABLED, false);
+  const scheduler = optionalEnv('SCHEDULER', 'heuristic') as 'fixed' | 'heuristic' | 'bandit';
+  const enableMdns = parseBool(process.env.ENABLE_MDNS, false);
+  const suppressReplicationIngest = parseBool(process.env.SUPPRESS_REPLICATION_INGEST, false) || role === 'late-joiner';
+
+  const redis = createClient({ url: redisUrl });
+  redis.on('error', (error: unknown) => {
+    logger.error(`[compose:${index}] Redis error: ${String(error)}`);
+  });
+  await redis.connect();
+
+  const baseTransport = createRedisNodeTransport(redis, index, (code) => {
+    void redis.quit().finally(() => process.exit(code));
+  });
+
+  const transport: NodeRunnerTransport = {
+    onMessage: baseTransport.onMessage,
+    exit: baseTransport.exit,
+    postMessage: (message: NodeRunnerOutboundMessage) => {
+      if (message.type === 'done' && message.stats) {
+        void redis.set(statsKey(index), JSON.stringify(message.stats));
+      }
+      if (message.type === 'listen_addrs_report' && message.addrs) {
+        void redis.set(addrsKey(index), JSON.stringify(message.addrs));
+      }
+      baseTransport.postMessage(message);
+    },
+  };
+
+  const config: WorkerData = {
+    index,
+    totalNodes,
+    nodeSeed,
+    networkId,
+    pubsubTopic,
+    bootstrapMultiaddrs: [],
+    runDurationSec: 3600,
+    messageRate: 1,
+    dataSyncEnabled: true,
+    testType: 'REPLICATION',
+    replicationType: 'TOPIC_BASED',
+    syncIntervalMs,
+    adaptive: {
+      enabled: adaptiveEnabled,
+      scheduler,
+      minIntervalMs: Math.min(5_000, syncIntervalMs),
+      maxIntervalMs: syncIntervalMs,
+    },
+    enableMdns,
+    suppressReplicationIngest,
+    listenAddrs: [`/ip4/0.0.0.0/tcp/${listenPort}`],
+    advertiseHost,
+  };
+
+  logger.info(
+    `[compose:${index}] starting role=${role} host=${advertiseHost} port=${listenPort} adaptive=${adaptiveEnabled}`,
+  );
+
+  await startNodeRunner(config, transport, {
+    logLabel: `compose:${index}`,
+    onReady: async () => {
+      await redis.lPush(cmdKey(index), JSON.stringify({ type: 'report_listen_addrs' }));
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        if (await redis.get(addrsKey(index))) break;
+        await sleep(100);
+      }
+      await redis.set(readyKey(index), '1');
+      logger.info(`[compose:${index}] ready`);
+    },
+  });
+};
+
+main().catch((error: unknown) => {
+  console.error('composeNodeMain failed', error);
+  process.exit(1);
+});

--- a/packages/core/tests/compose-interop/composeNodeMain.ts
+++ b/packages/core/tests/compose-interop/composeNodeMain.ts
@@ -1,3 +1,4 @@
+import { networkInterfaces } from 'node:os';
 import { logger } from '@dechat/common';
 import { createClient } from 'redis';
 import { type NodeRunnerOutboundMessage, type NodeRunnerTransport, startNodeRunner } from '../interop/nodeRunner';
@@ -20,6 +21,22 @@ const parseBool = (value: string | undefined, fallback: boolean): boolean => {
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
+/** Prefer a non-loopback IPv4 so peers dial `/ip4/...` (libp2p dns4 is unreliable in Compose). */
+const detectAdvertiseHost = (fallback: string): string => {
+  const forced = process.env.ADVERTISE_IP;
+  if (forced) return forced;
+
+  for (const addrs of Object.values(networkInterfaces())) {
+    for (const addr of addrs ?? []) {
+      const family = typeof addr.family === 'string' ? addr.family : String(addr.family);
+      if ((family === 'IPv4' || family === '4') && !addr.internal) {
+        return addr.address;
+      }
+    }
+  }
+  return fallback;
+};
+
 process.on('unhandledRejection', (reason) => {
   logger.warn(`[composeNode] Suppressed unhandledRejection: ${String(reason)}`);
 });
@@ -30,7 +47,7 @@ const main = async (): Promise<void> => {
   const role = requireEnv('ROLE');
   const redisUrl = requireEnv('REDIS_URL');
   const listenPort = Number(optionalEnv('LISTEN_PORT', '4001'));
-  const advertiseHost = optionalEnv('ADVERTISE_HOST', `dechat-node-${index}`);
+  const advertiseHost = detectAdvertiseHost(optionalEnv('ADVERTISE_HOST', `dechat-node-${index}`));
   const networkId = optionalEnv('NETWORK_ID', 'compose-interop');
   const pubsubTopic = optionalEnv('PUBSUB_TOPIC', '/dechat/compose/v1');
   const nodeSeed = optionalEnv('NODE_SEED', `Compose-Node-${index}`);

--- a/packages/core/tests/compose-interop/composeOrchestrator.ts
+++ b/packages/core/tests/compose-interop/composeOrchestrator.ts
@@ -1,0 +1,123 @@
+import { logger } from '@dechat/common';
+import { createClient, type RedisClientType } from 'redis';
+import type { NodeRunnerInboundMessage, NodeRunnerOutboundMessage } from '../interop/nodeRunner';
+import type { WorkerResult } from '../interop/types';
+import { addrsKey, cmdKey, evtKey, readyKey, statsKey } from './composeKeys';
+
+export type ComposeOrchestrator = {
+  readonly redis: RedisClientType;
+  readonly send: (index: number, message: NodeRunnerInboundMessage) => Promise<void>;
+  readonly waitReady: (indices: readonly number[], timeoutMs: number) => Promise<void>;
+  readonly waitEvent: (index: number, type: string, timeoutMs: number) => Promise<NodeRunnerOutboundMessage>;
+  readonly getAddrs: (index: number) => Promise<string[]>;
+  readonly getStats: (index: number) => Promise<WorkerResult | undefined>;
+  readonly requestStatistics: (index: number, timeoutMs: number) => Promise<WorkerResult>;
+  readonly requestHashes: (index: number, timeoutMs: number) => Promise<readonly string[]>;
+  readonly requestListenAddrs: (index: number, timeoutMs: number) => Promise<{ peerId: string; addrs: string[] }>;
+  readonly close: () => Promise<void>;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const createComposeOrchestrator = async (redisUrl: string): Promise<ComposeOrchestrator> => {
+  const redis = createClient({ url: redisUrl });
+  redis.on('error', (error: unknown) => {
+    logger.error(`Compose orchestrator Redis error: ${String(error)}`);
+  });
+  await redis.connect();
+
+  const pending = new Map<number, NodeRunnerOutboundMessage[]>();
+
+  const enqueue = (index: number, message: NodeRunnerOutboundMessage): void => {
+    const queue = pending.get(index) ?? [];
+    queue.push(message);
+    pending.set(index, queue);
+  };
+
+  const dequeueType = (index: number, type: string): NodeRunnerOutboundMessage | undefined => {
+    const queue = pending.get(index) ?? [];
+    const at = queue.findIndex((message) => message.type === type);
+    if (at < 0) return undefined;
+    const [message] = queue.splice(at, 1);
+    pending.set(index, queue);
+    return message;
+  };
+
+  const send = async (index: number, message: NodeRunnerInboundMessage): Promise<void> => {
+    await redis.lPush(cmdKey(index), JSON.stringify(message));
+  };
+
+  const waitReady = async (indices: readonly number[], timeoutMs: number): Promise<void> => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const flags = await Promise.all(indices.map((i) => redis.get(readyKey(i))));
+      if (flags.every((v) => v === '1')) return;
+      await sleep(500);
+    }
+    throw new Error(`Timeout waiting for ready nodes: ${indices.join(',')}`);
+  };
+
+  const waitEvent = async (index: number, type: string, timeoutMs: number): Promise<NodeRunnerOutboundMessage> => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const buffered = dequeueType(index, type);
+      if (buffered) return buffered;
+
+      const remainingSec = Math.max(1, Math.ceil((deadline - Date.now()) / 1000));
+      const result = await redis.brPop(evtKey(index), Math.min(remainingSec, 5));
+      if (!result) continue;
+      const message = JSON.parse(result.element) as NodeRunnerOutboundMessage;
+      if (message.type === type) return message;
+      enqueue(index, message);
+    }
+    throw new Error(`Timeout waiting for event ${type} from node ${index}`);
+  };
+
+  const getAddrs = async (index: number): Promise<string[]> => {
+    const raw = await redis.get(addrsKey(index));
+    if (!raw) return [];
+    return JSON.parse(raw) as string[];
+  };
+
+  const getStats = async (index: number): Promise<WorkerResult | undefined> => {
+    const raw = await redis.get(statsKey(index));
+    if (!raw) return undefined;
+    return JSON.parse(raw) as WorkerResult;
+  };
+
+  const requestStatistics = async (index: number, timeoutMs: number): Promise<WorkerResult> => {
+    await send(index, { type: 'statistics' });
+    const evt = await waitEvent(index, 'statistics', timeoutMs);
+    if (!evt.stats) throw new Error(`Node ${index} statistics event missing stats`);
+    return evt.stats;
+  };
+
+  const requestHashes = async (index: number, timeoutMs: number): Promise<readonly string[]> => {
+    await send(index, { type: 'report_hashes' });
+    const evt = await waitEvent(index, 'hashes_report', timeoutMs);
+    return evt.hashes ?? [];
+  };
+
+  const requestListenAddrs = async (index: number, timeoutMs: number): Promise<{ peerId: string; addrs: string[] }> => {
+    await send(index, { type: 'report_listen_addrs' });
+    const evt = await waitEvent(index, 'listen_addrs_report', timeoutMs);
+    return { peerId: evt.peerId ?? '', addrs: evt.addrs ?? [] };
+  };
+
+  const close = async (): Promise<void> => {
+    await redis.quit();
+  };
+
+  return {
+    redis,
+    send,
+    waitReady,
+    waitEvent,
+    getAddrs,
+    getStats,
+    requestStatistics,
+    requestHashes,
+    requestListenAddrs,
+    close,
+  };
+};

--- a/packages/core/tests/compose-interop/docker-compose.yml
+++ b/packages/core/tests/compose-interop/docker-compose.yml
@@ -1,0 +1,32 @@
+name: dechat-compose-interop
+
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 2s
+      timeout: 2s
+      retries: 20
+
+  node:
+    build:
+      context: ../../../..
+      dockerfile: packages/core/tests/compose-interop/Dockerfile
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      REDIS_URL: redis://redis:6379
+      LISTEN_PORT: '4001'
+      LOG_LEVEL: INFO
+      NODE_ENV: perf
+    networks:
+      - dechat-interop
+    # Individual containers are started by scripts/run-scenario.sh with per-node env.
+
+networks:
+  dechat-interop:
+    name: dechat-compose-interop

--- a/packages/core/tests/compose-interop/docker-compose.yml
+++ b/packages/core/tests/compose-interop/docker-compose.yml
@@ -24,9 +24,9 @@ services:
       LOG_LEVEL: INFO
       NODE_ENV: perf
     networks:
-      - dechat-interop
+      - interop
     # Individual containers are started by scripts/run-scenario.sh with per-node env.
 
 networks:
-  dechat-interop:
-    name: dechat-compose-interop
+  interop:
+    name: dechat-interop-net

--- a/packages/core/tests/compose-interop/redisTransport.ts
+++ b/packages/core/tests/compose-interop/redisTransport.ts
@@ -1,0 +1,47 @@
+import { logger } from '@dechat/common';
+import type { RedisClientType } from 'redis';
+import type { NodeRunnerInboundMessage, NodeRunnerOutboundMessage, NodeRunnerTransport } from '../interop/nodeRunner';
+import { cmdKey, evtKey } from './composeKeys';
+
+/**
+ * Redis list transport for Compose nodes.
+ * Commands: BRPOP `cmd:{index}` · Events: LPUSH `evt:{index}`
+ * Uses a dedicated blocking connection so LPUSH is never starved.
+ */
+export const createRedisNodeTransport = (
+  redis: RedisClientType,
+  index: number,
+  exitFn: (code: number) => void,
+): NodeRunnerTransport => {
+  let running = true;
+  const blocker = redis.duplicate();
+
+  return {
+    onMessage: (handler) => {
+      void (async () => {
+        await blocker.connect();
+        while (running) {
+          try {
+            const result = await blocker.brPop(cmdKey(index), 2);
+            if (!result) continue;
+            const message = JSON.parse(result.element) as NodeRunnerInboundMessage;
+            await handler(message);
+          } catch (error) {
+            if (!running) return;
+            logger.error(`[compose:${index}] Redis BRPOP handler failed: ${String(error)}`);
+          }
+        }
+      })();
+    },
+    postMessage: (message: NodeRunnerOutboundMessage) => {
+      void redis.lPush(evtKey(index), JSON.stringify(message)).catch((error: unknown) => {
+        logger.error(`[compose:${index}] Redis LPUSH failed: ${String(error)}`);
+      });
+    },
+    exit: (code) => {
+      running = false;
+      void blocker.quit().catch(() => undefined);
+      exitFn(code);
+    },
+  };
+};

--- a/packages/core/tests/compose-interop/reports/.gitignore
+++ b/packages/core/tests/compose-interop/reports/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitkeep
+!.gitignore

--- a/packages/core/tests/compose-interop/scenarios/late-joiner-adaptive.ts
+++ b/packages/core/tests/compose-interop/scenarios/late-joiner-adaptive.ts
@@ -1,0 +1,163 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { logger } from '@dechat/common';
+import { generateTestReport, printTestReport, summarizeAntiEntropyMetrics } from '../../interop/interopTestReporter';
+import {
+  computeLateJoinerPollTimeoutMs,
+  computeMeshStabilizeMs,
+  computeProducerConsensusTimeoutMs,
+  computeReplicateSettleMs,
+} from '../../interop/interopTiming';
+import type { AggregatedResult, WorkerResult } from '../../interop/types';
+import { createComposeOrchestrator } from '../composeOrchestrator';
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const percentile = (xs: number[], p: number): number => {
+  if (xs.length === 0) return -1;
+  const i = Math.floor((p / 100) * (xs.length - 1));
+  return xs[i];
+};
+
+const average = (xs: number[]): number => (xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length);
+
+const aggregate = (results: WorkerResult[]): AggregatedResult => {
+  const connections = results.map((r) => r.connections);
+  const verified = results.map((r) => r.verified);
+  const ttfvp = results.map((r) => r.ttfvpMs).filter((x) => x >= 0);
+  return {
+    workerResults: results,
+    summary: {
+      nodes: results.length,
+      connections: { p50: percentile(connections, 50), p95: percentile(connections, 95), avg: average(connections) },
+      verified: { p50: percentile(verified, 50), p95: percentile(verified, 95), avg: average(verified) },
+      ttfVerifiedMs: { p50: percentile(ttfvp, 50), p95: percentile(ttfvp, 95), avg: average(ttfvp) },
+    },
+  };
+};
+
+const main = async (): Promise<void> => {
+  const totalNodes = Number(process.env.COMPOSE_NODES ?? '7');
+  const producerCount = totalNodes - 1;
+  const lateJoinerIndex = totalNodes - 1;
+  const redisUrl = process.env.REDIS_URL ?? 'redis://127.0.0.1:6379';
+  const syncIntervalMs = Number(process.env.SYNC_INTERVAL_MS ?? '15000');
+  const startedAt = Date.now();
+
+  const producers = Array.from({ length: producerCount }, (_, i) => i);
+  const orch = await createComposeOrchestrator(redisUrl);
+
+  try {
+    logger.info(`[compose-orch] waiting for ${producerCount} producers + late joiner ready`);
+    await orch.waitReady([...producers, lateJoinerIndex], 120_000);
+
+    // Explicit mesh: each producer dials every other producer.
+    const addrReports = await Promise.all(
+      producers.map(async (index) => {
+        const cached = await orch.getAddrs(index);
+        if (cached.length > 0) return { index, addrs: cached };
+        return { index, ...(await orch.requestListenAddrs(index, 15_000)) };
+      }),
+    );
+    const allProducerAddrs = Array.from(new Set(addrReports.flatMap((r) => r.addrs)));
+
+    for (const index of producers) {
+      const peers = allProducerAddrs.filter(
+        (addr) => !addrReports.find((r) => r.index === index)?.addrs.includes(addr),
+      );
+      await orch.send(index, { type: 'connect_peers', multiaddrs: peers.length > 0 ? peers : allProducerAddrs });
+      await orch.waitEvent(index, 'connect_peers_done', 60_000);
+    }
+
+    const stabilizeMs = computeMeshStabilizeMs(totalNodes);
+    logger.info(`[compose-orch] mesh stabilize ${stabilizeMs}ms`);
+    await sleep(stabilizeMs);
+
+    for (const index of producers) {
+      await orch.send(index, { type: 'produce_messages_replication' });
+    }
+
+    const settleMs = computeReplicateSettleMs(totalNodes);
+    logger.info(`[compose-orch] replicate settle ${settleMs}ms`);
+    await sleep(settleMs);
+
+    const consensusDeadline = Date.now() + computeProducerConsensusTimeoutMs(totalNodes);
+    let consensus = false;
+    while (Date.now() < consensusDeadline) {
+      const stats = await Promise.all(producers.map((i) => orch.requestStatistics(i, 15_000)));
+      const counts = stats.map((s) => s.replicaCount ?? 0);
+      const min = Math.min(...counts);
+      const max = Math.max(...counts);
+      logger.info(`[compose-orch] producer replicas min=${min} max=${max}`);
+      if (min > 0 && min === max) {
+        consensus = true;
+        break;
+      }
+      await sleep(5_000);
+    }
+    if (!consensus) {
+      throw new Error('Producer replica consensus timeout');
+    }
+
+    const hashSets = await Promise.all(producers.map((i) => orch.requestHashes(i, 15_000)));
+    const expectedHashes = Array.from(new Set(hashSets.flat()));
+    logger.info(`[compose-orch] expectedHashes=${expectedHashes.length}`);
+
+    await orch.send(lateJoinerIndex, { type: 'set_expected_hashes', hashes: expectedHashes });
+    await orch.send(lateJoinerIndex, { type: 'connect_peers', multiaddrs: allProducerAddrs });
+    await orch.waitEvent(lateJoinerIndex, 'connect_peers_done', 60_000);
+    await sleep(20_000);
+
+    const pollTimeout = computeLateJoinerPollTimeoutMs(totalNodes, syncIntervalMs);
+    const pollDeadline = Date.now() + pollTimeout;
+    let lateStats: WorkerResult | undefined;
+    while (Date.now() < pollDeadline) {
+      lateStats = await orch.requestStatistics(lateJoinerIndex, 15_000);
+      logger.info(
+        `[compose-orch] late joiner hasTargetData=${String(lateStats.hasTargetData)} usefulSyncs=${lateStats.antiEntropy?.usefulSyncs ?? 0}`,
+      );
+      if (lateStats.hasTargetData === true) break;
+      await sleep(2_000);
+    }
+
+    if (lateStats?.hasTargetData !== true) {
+      throw new Error(`Late joiner failed to converge within ${pollTimeout}ms`);
+    }
+
+    const producerStats = await Promise.all(producers.map((i) => orch.requestStatistics(i, 15_000)));
+    const allStats = [...producerStats, lateStats];
+
+    for (const index of [...producers, lateJoinerIndex]) {
+      await orch.send(index, { type: 'terminate' });
+    }
+    await sleep(3_000);
+
+    const aggregated = aggregate(allStats);
+    const passed = true;
+    const report = generateTestReport(
+      'compose-late-joiner-adaptive',
+      totalNodes,
+      Date.now() - startedAt,
+      aggregated,
+      passed,
+      {
+        antiEntropy: summarizeAntiEntropyMetrics(allStats),
+        scenarioWallMs: Date.now() - startedAt,
+      },
+    );
+    printTestReport(report);
+
+    const reportsDir = resolve(process.cwd(), 'tests/compose-interop/reports');
+    mkdirSync(reportsDir, { recursive: true });
+    const out = resolve(reportsDir, `compose-late-joiner-adaptive-${report.timestamp.replace(/[:.]/g, '-')}.json`);
+    writeFileSync(out, JSON.stringify(report, null, 2));
+    logger.info(`[compose-orch] wrote ${out}`);
+  } finally {
+    await orch.close();
+  }
+};
+
+main().catch((error: unknown) => {
+  console.error('late-joiner-adaptive orchestrator failed', error);
+  process.exit(1);
+});

--- a/packages/core/tests/compose-interop/scenarios/late-joiner-adaptive.ts
+++ b/packages/core/tests/compose-interop/scenarios/late-joiner-adaptive.ts
@@ -102,6 +102,18 @@ const main = async (): Promise<void> => {
     const hashSets = await Promise.all(producers.map((i) => orch.requestHashes(i, 15_000)));
     const expectedHashes = Array.from(new Set(hashSets.flat()));
     logger.info(`[compose-orch] expectedHashes=${expectedHashes.length}`);
+    logger.info(`[compose-orch] producer addrs sample=${allProducerAddrs.slice(0, 3).join(',')}`);
+
+    // Equal replica counts alone can mean "each node only has local data" (no mesh).
+    for (let i = 0; i < producers.length; i++) {
+      const local = new Set(hashSets[i]);
+      const missing = expectedHashes.filter((h) => !local.has(h)).length;
+      if (missing > 0) {
+        throw new Error(
+          `Producer ${producers[i]} missing ${missing}/${expectedHashes.length} hashes after mesh — dial/advertise broken`,
+        );
+      }
+    }
 
     await orch.send(lateJoinerIndex, { type: 'set_expected_hashes', hashes: expectedHashes });
     await orch.send(lateJoinerIndex, { type: 'connect_peers', multiaddrs: allProducerAddrs });

--- a/packages/core/tests/compose-interop/scripts/run-scenario.sh
+++ b/packages/core/tests/compose-interop/scripts/run-scenario.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Start Redis + N Compose nodes, run late-joiner orchestrator on the host, tear down.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CORE_DIR="$(cd "${COMPOSE_DIR}/../.." && pwd)"
+REPO_ROOT="$(cd "${CORE_DIR}/../.." && pwd)"
+COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
+PROJECT="dechat-compose-interop"
+
+COMPOSE_NODES="${COMPOSE_NODES:-7}"
+ADAPTIVE_ENABLED="${ADAPTIVE_ENABLED:-true}"
+SCHEDULER="${SCHEDULER:-heuristic}"
+SYNC_INTERVAL_MS="${SYNC_INTERVAL_MS:-15000}"
+NETWORK_ID="${NETWORK_ID:-compose-interop-$(date +%s)}"
+LISTEN_PORT="${LISTEN_PORT:-4001}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required" >&2
+  exit 1
+fi
+
+cleanup() {
+  echo "[compose] teardown"
+  # Stop named node containers if still running
+  for i in $(seq 0 $((COMPOSE_NODES - 1))); do
+    docker rm -f "dechat-node-${i}" >/dev/null 2>&1 || true
+  done
+  docker compose -p "${PROJECT}" -f "${COMPOSE_FILE}" down -v --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cd "${REPO_ROOT}"
+
+echo "[compose] build image + start redis"
+docker compose -p "${PROJECT}" -f "${COMPOSE_FILE}" build node
+docker compose -p "${PROJECT}" -f "${COMPOSE_FILE}" up -d redis
+
+echo "[compose] waiting for redis"
+for _ in $(seq 1 60); do
+  if docker compose -p "${PROJECT}" -f "${COMPOSE_FILE}" exec -T redis redis-cli ping 2>/dev/null | grep -q PONG; then
+    break
+  fi
+  sleep 1
+done
+
+NETWORK_NAME="dechat-compose-interop"
+PRODUCER_COUNT=$((COMPOSE_NODES - 1))
+
+echo "[compose] starting ${PRODUCER_COUNT} producers + 1 late joiner (total=${COMPOSE_NODES})"
+for i in $(seq 0 $((COMPOSE_NODES - 1))); do
+  if [[ "${i}" -eq "${PRODUCER_COUNT}" ]]; then
+    ROLE="late-joiner"
+  else
+    ROLE="producer"
+  fi
+
+  docker compose -p "${PROJECT}" -f "${COMPOSE_FILE}" run -d \
+    --name "dechat-node-${i}" \
+    --network-alias "dechat-node-${i}" \
+    -e NODE_INDEX="${i}" \
+    -e TOTAL_NODES="${COMPOSE_NODES}" \
+    -e ROLE="${ROLE}" \
+    -e ADVERTISE_HOST="dechat-node-${i}" \
+    -e LISTEN_PORT="${LISTEN_PORT}" \
+    -e NETWORK_ID="${NETWORK_ID}" \
+    -e ADAPTIVE_ENABLED="${ADAPTIVE_ENABLED}" \
+    -e SCHEDULER="${SCHEDULER}" \
+    -e SYNC_INTERVAL_MS="${SYNC_INTERVAL_MS}" \
+    -e ENABLE_MDNS=false \
+    -e REDIS_URL=redis://redis:6379 \
+    node >/dev/null
+
+  echo "[compose] started dechat-node-${i} role=${ROLE}"
+done
+
+export COMPOSE_NODES ADAPTIVE_ENABLED SCHEDULER SYNC_INTERVAL_MS
+export REDIS_URL="${REDIS_URL:-redis://127.0.0.1:6379}"
+
+echo "[compose] running orchestrator against ${REDIS_URL}"
+cd "${CORE_DIR}"
+NODE_ENV=perf LOG_LEVEL=INFO node dist/tests/compose-interop/scenarios/late-joiner-adaptive.js
+
+echo "[compose] scenario passed"

--- a/packages/core/tests/compose-interop/scripts/run-scenario.sh
+++ b/packages/core/tests/compose-interop/scripts/run-scenario.sh
@@ -8,6 +8,7 @@ CORE_DIR="$(cd "${COMPOSE_DIR}/../.." && pwd)"
 REPO_ROOT="$(cd "${CORE_DIR}/../.." && pwd)"
 COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
 PROJECT="dechat-compose-interop"
+NETWORK_NAME="dechat-compose-interop"
 
 COMPOSE_NODES="${COMPOSE_NODES:-7}"
 ADAPTIVE_ENABLED="${ADAPTIVE_ENABLED:-true}"
@@ -23,7 +24,6 @@ fi
 
 cleanup() {
   echo "[compose] teardown"
-  # Stop named node containers if still running
   for i in $(seq 0 $((COMPOSE_NODES - 1))); do
     docker rm -f "dechat-node-${i}" >/dev/null 2>&1 || true
   done
@@ -45,7 +45,8 @@ for _ in $(seq 1 60); do
   sleep 1
 done
 
-NETWORK_NAME="dechat-compose-interop"
+# Image name from compose project (see `docker compose images`).
+NODE_IMAGE="${PROJECT}-node"
 PRODUCER_COUNT=$((COMPOSE_NODES - 1))
 
 echo "[compose] starting ${PRODUCER_COUNT} producers + 1 late joiner (total=${COMPOSE_NODES})"
@@ -56,8 +57,11 @@ for i in $(seq 0 $((COMPOSE_NODES - 1))); do
     ROLE="producer"
   fi
 
-  docker compose -p "${PROJECT}" -f "${COMPOSE_FILE}" run -d \
+  # Use docker run (not compose run): need --network-alias for dns4 advertise hosts.
+  docker run -d \
     --name "dechat-node-${i}" \
+    --hostname "dechat-node-${i}" \
+    --network "${NETWORK_NAME}" \
     --network-alias "dechat-node-${i}" \
     -e NODE_INDEX="${i}" \
     -e TOTAL_NODES="${COMPOSE_NODES}" \
@@ -70,7 +74,9 @@ for i in $(seq 0 $((COMPOSE_NODES - 1))); do
     -e SYNC_INTERVAL_MS="${SYNC_INTERVAL_MS}" \
     -e ENABLE_MDNS=false \
     -e REDIS_URL=redis://redis:6379 \
-    node >/dev/null
+    -e LOG_LEVEL="${LOG_LEVEL:-INFO}" \
+    -e NODE_ENV=perf \
+    "${NODE_IMAGE}" >/dev/null
 
   echo "[compose] started dechat-node-${i} role=${ROLE}"
 done

--- a/packages/core/tests/compose-interop/scripts/run-scenario.sh
+++ b/packages/core/tests/compose-interop/scripts/run-scenario.sh
@@ -8,7 +8,7 @@ CORE_DIR="$(cd "${COMPOSE_DIR}/../.." && pwd)"
 REPO_ROOT="$(cd "${CORE_DIR}/../.." && pwd)"
 COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
 PROJECT="dechat-compose-interop"
-NETWORK_NAME="dechat-compose-interop"
+NETWORK_NAME="dechat-interop-net"
 
 COMPOSE_NODES="${COMPOSE_NODES:-7}"
 ADAPTIVE_ENABLED="${ADAPTIVE_ENABLED:-true}"
@@ -44,6 +44,16 @@ for _ in $(seq 1 60); do
   fi
   sleep 1
 done
+
+# Prefer the explicit compose network name; fall back to whatever redis joined.
+REDIS_CID="$(docker compose -p "${PROJECT}" -f "${COMPOSE_FILE}" ps -q redis)"
+if [[ -n "${REDIS_CID}" ]]; then
+  DETECTED_NET="$(docker inspect -f '{{range $k, $v := .NetworkSettings.Networks}}{{println $k}}{{end}}' "${REDIS_CID}" | head -1 | tr -d '\r')"
+  if [[ -n "${DETECTED_NET}" ]]; then
+    NETWORK_NAME="${DETECTED_NET}"
+  fi
+fi
+echo "[compose] using network ${NETWORK_NAME}"
 
 # Image name from compose project (see `docker compose images`).
 NODE_IMAGE="${PROJECT}-node"

--- a/packages/core/tests/interop/childThread/workerUitls.ts
+++ b/packages/core/tests/interop/childThread/workerUitls.ts
@@ -60,6 +60,7 @@ export const configureNode = async (
     adaptive,
     bootstrapMultiaddrs = [],
     enableMdns = true,
+    listenAddrs = ['/ip4/0.0.0.0/tcp/0'],
   } = config;
 
   let strategies: DeChatStrategies = {
@@ -86,7 +87,7 @@ export const configureNode = async (
     nodeSeed,
     {
       network: {
-        listenAddrs: ['/ip4/0.0.0.0/tcp/0'],
+        listenAddrs,
         bootstrapPeers: bootstrapMultiaddrs,
         maxConnections: 150,
         minConnections: 8,

--- a/packages/core/tests/interop/nodeRunner.ts
+++ b/packages/core/tests/interop/nodeRunner.ts
@@ -53,6 +53,30 @@ export type NodeRunnerTransport = {
 export type NodeRunnerOptions = {
   /** Label for dial/debug logs (e.g. `Worker 3` or `compose:2`). */
   readonly logLabel?: string;
+  /** Fired after the node is started and command handlers are registered (before ping loop). */
+  readonly onReady?: () => void | Promise<void>;
+};
+
+const IPV4_HOST = /^\d{1,3}(?:\.\d{1,3}){3}$/;
+
+/** Rewrite wildcard listen multiaddrs into dialable advertise multiaddrs. */
+export const normalizeAdvertiseMultiaddrs = (
+  listenMultiaddrs: readonly string[],
+  peerId: string,
+  advertiseHost = '127.0.0.1',
+): string[] => {
+  const proto = IPV4_HOST.test(advertiseHost) ? 'ip4' : 'dns4';
+  const hostPrefix = `/${proto}/${advertiseHost}/`;
+  return listenMultiaddrs
+    .map((addr) => addr.replace('/ip4/0.0.0.0/', hostPrefix))
+    .filter((addr) => addr.includes(hostPrefix))
+    .map((addr) => (addr.includes('/p2p/') ? addr : `${addr}/p2p/${peerId}`));
+};
+
+const normalizeDialMultiaddr = (addrStr: string, advertiseHost = '127.0.0.1'): string => {
+  if (!addrStr.includes('/ip4/0.0.0.0/')) return addrStr;
+  const proto = IPV4_HOST.test(advertiseHost) ? 'ip4' : 'dns4';
+  return addrStr.replace('/ip4/0.0.0.0/', `/${proto}/${advertiseHost}/`);
 };
 
 export const mapAntiEntropySnapshot = (
@@ -106,12 +130,12 @@ export const startNodeRunner = async (
   const { testType } = config;
 
   if (testType === 'PROPAGATION') {
-    await runNodeDataPropagation(config, transport, logLabel);
+    await runNodeDataPropagation(config, transport, logLabel, options.onReady);
     return;
   }
 
   if (testType === 'REPLICATION') {
-    await runNodeDataReplication(config, transport, logLabel);
+    await runNodeDataReplication(config, transport, logLabel, options.onReady);
     return;
   }
 
@@ -122,6 +146,7 @@ const runNodeDataPropagation = async (
   config: WorkerData,
   transport: NodeRunnerTransport,
   _logLabel: string,
+  onReady?: () => void | Promise<void>,
 ): Promise<void> => {
   const latencies: number[] = [];
   let terminateThread = false;
@@ -293,6 +318,7 @@ const runNodeDataPropagation = async (
     }
   });
 
+  if (onReady) await onReady();
   await sendLoop();
 };
 
@@ -300,6 +326,7 @@ const runNodeDataReplication = async (
   config: WorkerData,
   transport: NodeRunnerTransport,
   logLabel: string,
+  onReady?: () => void | Promise<void>,
 ): Promise<void> => {
   const latencies: number[] = [];
   let terminateThread = false;
@@ -580,11 +607,11 @@ const runNodeDataReplication = async (
 
     if (message.type === 'report_listen_addrs') {
       const peerId = node.peerId.toString();
-      const addrs = node
-        .getMultiaddrs()
-        .map((addr) => addr.toString().replace('/ip4/0.0.0.0/', '/ip4/127.0.0.1/'))
-        .filter((addr) => addr.includes('/ip4/127.0.0.1/'))
-        .map((addr) => (addr.includes('/p2p/') ? addr : `${addr}/p2p/${peerId}`));
+      const addrs = normalizeAdvertiseMultiaddrs(
+        node.getMultiaddrs().map((addr) => addr.toString()),
+        peerId,
+        config.advertiseHost,
+      );
       transport.postMessage({ type: 'listen_addrs_report', index, peerId, addrs });
       return;
     }
@@ -595,7 +622,7 @@ const runNodeDataReplication = async (
 
       for (const addrStr of multiaddrs) {
         try {
-          const normalized = addrStr.replace('/ip4/0.0.0.0/', '/ip4/127.0.0.1/');
+          const normalized = normalizeDialMultiaddr(addrStr, config.advertiseHost);
           const ma = multiaddr(normalized);
           const addrPeerId = ma.getPeerId()?.toString();
           if (addrPeerId === from) continue;
@@ -625,5 +652,6 @@ const runNodeDataReplication = async (
     }
   });
 
+  if (onReady) await onReady();
   await sendLoop();
 };

--- a/packages/core/tests/interop/types.ts
+++ b/packages/core/tests/interop/types.ts
@@ -117,6 +117,13 @@ export type WorkerData = {
   enableMdns?: boolean; // default true; set false to isolate network partitions
   /** When true, gossip/direct replication ingest is deferred until set_expected_hashes */
   suppressReplicationIngest?: boolean;
+  /** Override libp2p listen multiaddrs (Compose uses fixed TCP ports). */
+  listenAddrs?: string[];
+  /**
+   * Host used when rewriting `/ip4/0.0.0.0/` listen addrs for dialing.
+   * IPv4 → `/ip4/<host>/…`; otherwise `/dns4/<host>/…`. Defaults to `127.0.0.1` (worker interop).
+   */
+  advertiseHost?: string;
 };
 
 export type WorkerDataConfig = {
@@ -139,6 +146,8 @@ export type WorkerDataConfig = {
   };
   enableMdns?: boolean; // default true; set false to isolate network partitions
   suppressReplicationIngest?: boolean;
+  listenAddrs?: string[];
+  advertiseHost?: string;
 };
 
 export type WorkerDetails = { workerData: WorkerData; workerRef: Worker };

--- a/packages/core/tests/unit/interop/nodeRunner.unit.test.ts
+++ b/packages/core/tests/unit/interop/nodeRunner.unit.test.ts
@@ -5,6 +5,7 @@ import {
   mapAntiEntropySnapshot,
   type NodeRunnerInboundMessage,
   type NodeRunnerOutboundMessage,
+  normalizeAdvertiseMultiaddrs,
 } from '../../interop/nodeRunner';
 
 const emptySnapshot = (): AntiEntropyMetricsSnapshot => ({
@@ -66,5 +67,19 @@ describe('nodeRunner transport seam', () => {
 
     transport.exit(0);
     expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('rewrites wildcard listen addrs to dns4 advertise hosts for Compose', () => {
+    const addrs = normalizeAdvertiseMultiaddrs(
+      ['/ip4/0.0.0.0/tcp/4001', '/ip4/127.0.0.1/tcp/4001'],
+      'QmPeer',
+      'dechat-node-0',
+    );
+    expect(addrs).toEqual(['/dns4/dechat-node-0/tcp/4001/p2p/QmPeer']);
+  });
+
+  it('rewrites wildcard listen addrs to ip4 for numeric advertise hosts', () => {
+    const addrs = normalizeAdvertiseMultiaddrs(['/ip4/0.0.0.0/tcp/4001'], 'QmPeer', '10.0.0.5');
+    expect(addrs).toEqual(['/ip4/10.0.0.5/tcp/4001/p2p/QmPeer']);
   });
 });

--- a/tasks/tier2-compose-interop.md
+++ b/tasks/tier2-compose-interop.md
@@ -191,11 +191,12 @@ packages/core/tests/
 
 ### PR D — Nightly CI + split-brain
 
-- [ ] `.github/workflows/compose-interop-nightly.yml`
+- [x] Path-filtered / dispatch Compose CI (landed early with PR B): `.github/workflows/compose-interop.yml` — late-joiner lan on GHA
+- [ ] `.github/workflows/compose-interop-nightly.yml` (or extend compose-interop.yml)
   - Jobs: `late-joiner-adaptive` (12 nodes, lan), `late-joiner-wan` (12 nodes, wan)
   - Always `docker compose down -v` in `if: always()`
 - [ ] Port split-brain scenario (P1)
-- [ ] Document flake policy: promote to PR gate only after 7 nights < 5% flake
+- [ ] Document flake policy: promote to required PR gate only after 7 nights < 5% flake
 
 **Acceptance:** Scheduled workflow green on `develop`; split-brain heal converges.
 

--- a/tasks/tier2-compose-interop.md
+++ b/tasks/tier2-compose-interop.md
@@ -3,7 +3,7 @@
 **Backlog ref:** [BACKLOG.md § Task 5.2](../BACKLOG.md#task-52-tier-2--docker-compose-interop-real-network-isolation-at-scale)  
 **ADR ref:** [docs/adr/0003-adaptive-anti-entropy-scheduling.md](../docs/adr/0003-adaptive-anti-entropy-scheduling.md)  
 **Prerequisite:** Tier 1 closed ([PR #37](https://github.com/Ahmed-Abdul-Rahman/de-chat/pull/37)) + Bandit merged ([PR #39](https://github.com/Ahmed-Abdul-Rahman/de-chat/pull/39)); nightlies healthy on `develop`  
-**Status:** Approved — PR A in progress (`feat/tier2-node-runner-extract`)  
+**Status:** PR A merged (#42). PR B in progress (`feat/tier2-compose-late-joiner`)  
 **Goal:** Prove anti-entropy convergence under **real TCP between containers** with optional latency / loss / partition profiles — without Testground.
 
 ---
@@ -308,8 +308,8 @@ Reply **approve** (or note changes) on these decisions before implementation sta
 ## Implementation status
 
 - [x] Approval (2026-07-17)
-- [x] PR A — `nodeRunner` extract ← **in progress** (`feat/tier2-node-runner-extract`; unit + `test:int:data-sync` green locally)
-- [ ] PR B — Compose + late joiner (lan)
+- [x] PR A — `nodeRunner` extract ([PR #42](https://github.com/Ahmed-Abdul-Rahman/de-chat/pull/42) merged)
+- [ ] PR B — Compose + late joiner (lan) ← **in progress** (`feat/tier2-compose-late-joiner`)
 - [ ] PR C — A/B + netem
 - [ ] PR D — Nightly CI + split-brain
 - [ ] Optional: promote Compose job to PR gate after soak

--- a/yarn.lock
+++ b/yarn.lock
@@ -362,6 +362,7 @@ __metadata:
     level: "npm:^8.0.0"
     libp2p: "npm:^2.5.0"
     lru-cache: "npm:^11.2.4"
+    redis: "npm:^6.1.0"
     type-fest: "npm:^5.6.0"
     typescript: "npm:^5.5.0"
   languageName: unknown
@@ -1279,6 +1280,59 @@ __metadata:
   version: 1.0.0-next.29
   resolution: "@polka/url@npm:1.0.0-next.29"
   checksum: 10c0/0d58e081844095cb029d3c19a659bfefd09d5d51a2f791bc61eba7ea826f13d6ee204a8a448c2f5a855c17df07b37517373ff916dd05801063c0568ae9937684
+  languageName: node
+  linkType: hard
+
+"@redis/bloom@npm:6.1.0":
+  version: 6.1.0
+  resolution: "@redis/bloom@npm:6.1.0"
+  peerDependencies:
+    "@redis/client": ^6.1.0
+  checksum: 10c0/22704808088120471a12f8eb1e356c0082c7bb292b027677124def438a9ecd0b4614f62654eb4bae8375617e173b1daf6932218ea239b25521684e95d17665d5
+  languageName: node
+  linkType: hard
+
+"@redis/client@npm:6.1.0":
+  version: 6.1.0
+  resolution: "@redis/client@npm:6.1.0"
+  dependencies:
+    cluster-key-slot: "npm:1.1.2"
+  peerDependencies:
+    "@node-rs/xxhash": ^1.1.0
+    "@opentelemetry/api": ">=1 <2"
+  peerDependenciesMeta:
+    "@node-rs/xxhash":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+  checksum: 10c0/54a63e518c37e7448efe0a0ca21a539872c4f074b0f303dc50cad13e9fb35dabde54947f47c27716e4fb3870cf4f2ba65fdcc9a323eef0e66dc376248d07a146
+  languageName: node
+  linkType: hard
+
+"@redis/json@npm:6.1.0":
+  version: 6.1.0
+  resolution: "@redis/json@npm:6.1.0"
+  peerDependencies:
+    "@redis/client": ^6.1.0
+  checksum: 10c0/b500a9076946c7fb9041e83a3e42896d45f29d0a81b657b935ff870c952d94a5cf5aa640c517e5f318ff961c69ec1b7840754ec680d415c502b869947ba37228
+  languageName: node
+  linkType: hard
+
+"@redis/search@npm:6.1.0":
+  version: 6.1.0
+  resolution: "@redis/search@npm:6.1.0"
+  peerDependencies:
+    "@redis/client": ^6.1.0
+  checksum: 10c0/4865753c3826f3bba0edb5da94c498f8c6c9196ccd5108f4c4fa59a29db79df0844410889f7b32679ddfcd5d36d8c7ae9dca72a42ebd4f6e5ac91f15a7770e80
+  languageName: node
+  linkType: hard
+
+"@redis/time-series@npm:6.1.0":
+  version: 6.1.0
+  resolution: "@redis/time-series@npm:6.1.0"
+  peerDependencies:
+    "@redis/client": ^6.1.0
+  checksum: 10c0/eb792dd1ed5a591483d5008a3fbb3a3a0ca3df8eed73f68cb3c490ad6eba559a696b8ce4321a875e980e9ae615b55c2b55c17bd733f96532c2a2b9d51c298b64
   languageName: node
   linkType: hard
 
@@ -2307,6 +2361,13 @@ __metadata:
     node-gyp: "npm:latest"
     node-gyp-build: "npm:^4.3.0"
   checksum: 10c0/ba769e0b558ab466cef9468f7494b67d8f0139768630ba184d67b33201e67aad274718f3b1b78aaf3c5f5ab4cc526971edf82c7060741031bbad357952e7304d
+  languageName: node
+  linkType: hard
+
+"cluster-key-slot@npm:1.1.2":
+  version: 1.1.2
+  resolution: "cluster-key-slot@npm:1.1.2"
+  checksum: 10c0/d7d39ca28a8786e9e801eeb8c770e3c3236a566625d7299a47bb71113fb2298ce1039596acb82590e598c52dbc9b1f088c8f587803e697cb58e1867a95ff94d3
   languageName: node
   linkType: hard
 
@@ -4678,6 +4739,19 @@ __metadata:
   dependencies:
     picomatch: "npm:^2.2.1"
   checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
+  languageName: node
+  linkType: hard
+
+"redis@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "redis@npm:6.1.0"
+  dependencies:
+    "@redis/bloom": "npm:6.1.0"
+    "@redis/client": "npm:6.1.0"
+    "@redis/json": "npm:6.1.0"
+    "@redis/search": "npm:6.1.0"
+    "@redis/time-series": "npm:6.1.0"
+  checksum: 10c0/0fa18ea959a34c34a506b81029a525c457695d193ea3205f19380fc546c57f8f497c0fc12c2cfc35583df849f5439e1bd32a937065fb22d3f3cce722eb3f7308
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add Compose interop stack: Dockerfile, Redis barriers, `composeNodeMain` Redis transport, late-joiner orchestrator + `test:compose:late-joiner` script.
- Extend `WorkerData` / `configureNode` / `nodeRunner` with fixed `listenAddrs` + `advertiseHost` (dns4) for cross-container dials.
- Depends on merged PR A (#42) shared `nodeRunner`.

## Test plan
- [x] `vitest` `nodeRunner.unit.test.ts` (incl. advertise multiaddr helpers)
- [x] `yarn workspace @dechat/core build`
- [ ] `yarn workspace @dechat/core test:compose:late-joiner` (requires Docker — not available in agent environment; please run locally)
- [ ] Confirm teardown leaves no `dechat-node-*` containers / compose project volumes
- [ ] CI unit + existing interop still green

## Notes
- Plan: `tasks/tier2-compose-interop.md` (PR B)
- Nightly Compose workflow and netem land in PR C/D
- Default production `adaptive.enabled` unchanged

Made with [Cursor](https://cursor.com)